### PR TITLE
Improve navigating by tag

### DIFF
--- a/app/lib/photo_tagger/gallery.ex
+++ b/app/lib/photo_tagger/gallery.ex
@@ -253,7 +253,7 @@ defmodule PhotoTagger.Gallery do
   end
 
   def list_tags() do
-    Repo.all(Tag)
+    Repo.all(from t in Tag, order_by: [asc: t.name])
   end
 
   defp get_folder_path(folder) do

--- a/app/lib/photo_tagger_web/controllers/photo_controller.ex
+++ b/app/lib/photo_tagger_web/controllers/photo_controller.ex
@@ -165,7 +165,6 @@ defmodule PhotoTaggerWeb.PhotoController do
 
     tags = Map.get(params, "query_tags", [])
     tags = if is_list(tags), do: tags, else: [tags]
-    tags = Enum.uniq(tags ++ [tag])
 
     conn
     |> redirect(to: build_url(Map.get(params, "folder"), photo, tags))

--- a/app/lib/photo_tagger_web/controllers/photo_controller.ex
+++ b/app/lib/photo_tagger_web/controllers/photo_controller.ex
@@ -56,9 +56,10 @@ defmodule PhotoTaggerWeb.PhotoController do
         MapSet.union(acc, MapSet.new(photo.tags))
       end)
       |> MapSet.to_list()
+      |> Enum.sort_by(& &1.name)
 
     all_folders = Gallery.list_folders_include_tags()
-    all_tags = Gallery.list_tags() |> Enum.map(&(&1.name))
+    all_tags = Gallery.list_tags()
 
     %{
       folder: folder,
@@ -76,6 +77,9 @@ defmodule PhotoTaggerWeb.PhotoController do
     tags = if is_list(tags), do: tags, else: [tags]
 
     state = expand_state(%{folder: Map.get(params, "folder"), tags: tags, photo_id: Map.get(params, "photo_id")})
+    Logger.debug("all_tags: #{inspect(state.all_tags |> Enum.map(&(&1.name)))}")
+    Logger.debug("recommended_tags: #{inspect(state.recommended_tags |> Enum.map(&(&1.name)))}")
+
     conn
     |> render(:main, state)
   end

--- a/app/lib/photo_tagger_web/controllers/photo_html.ex
+++ b/app/lib/photo_tagger_web/controllers/photo_html.ex
@@ -57,17 +57,11 @@ defmodule PhotoTaggerWeb.PhotoHTML do
           <li>
             <.link class={"#{folder.name == @folder && "font-bold"}"} href={build_url(folder.name, nil, [])}><%= folder.name %></.link>
             <ul class="list-disc list-inside">
-              <%= for tag <- Enum.sort_by(folder.tags, fn tag ->
-                recommended_tags = Enum.map(@recommended_tags, & &1.name)
-                cond do
-                  tag in @tags -> 0 # Currently selected tags should appear first
-                  tag in recommended_tags -> 1 # followed by recommended tags
-                  true -> 2 # then all other tags
-                end
-              end) do %>
+              <%= for tag <- folder.tags do %>
+                <% recommended_tag_names = Enum.map(@recommended_tags, & &1.name) %>
                 <li>
                   <.link class={"#{@folder == folder.name && tag in @tags && "font-bold"}"} href={build_url(folder.name, nil, [tag])}><%= tag %></.link>
-                  <%= if @folder == folder.name do %>
+                  <%= if @folder == folder.name && tag in recommended_tag_names do %>
                     <.toggle_tag_button folder={folder.name} photo={nil} tags={@tags} toggled_tag={tag}><%= if(tag in @tags, do: "-", else: "+") %></.toggle_tag_button>
                   <% end %>
                 </li>

--- a/app/lib/photo_tagger_web/controllers/photo_html.ex
+++ b/app/lib/photo_tagger_web/controllers/photo_html.ex
@@ -42,7 +42,7 @@ defmodule PhotoTaggerWeb.PhotoHTML do
         <li>
           <.link class={"#{@folder == nil && "font-bold"}"} href={build_url(nil, nil, [])}>All folders</.link>
           <ul class="list-disc list-inside">
-            <%= for tag <- @all_tags do %>
+            <%= for %{name: tag} <- @all_tags do %>
               <li>
                 <.link class={"#{@folder == nil && tag in @tags && "font-bold"}"} href={build_url(nil, nil, [tag])}><%= tag %></.link>
                 <%= if @folder == nil do %>

--- a/app/lib/photo_tagger_web/controllers/photo_html.ex
+++ b/app/lib/photo_tagger_web/controllers/photo_html.ex
@@ -19,11 +19,11 @@ defmodule PhotoTaggerWeb.PhotoHTML do
         true -> assigns.tags ++ [assigns.toggled_tag]
       end
     assigns = assign(assigns, :href, build_url(assigns.folder, assigns.photo, tags_list))
-        #{if(@toggled_tag in @tags, do: "bg-red-500 text-black hover:text-black", else: "bg-green-500 text-white hover:text-white")}
     ~H"""
       <.link class={"
         #{@toggled_tag in @tags && "font-bold"}
-        rounded-full px-1"} href={@href}>
+        #{if(@toggled_tag in @tags, do: "bg-red-400 text-black hover:text-black", else: "bg-green-500 text-white hover:text-white")}
+        rounded-full px-1 no-underline"} href={@href}>
         <%= render_slot(@inner_block) %>
       </.link>
     """
@@ -31,6 +31,7 @@ defmodule PhotoTaggerWeb.PhotoHTML do
 
   attr(:all_folders, :list, required: true)
   attr(:all_tags, :list, required: true)
+  attr(:recommended_tags, :list, required: true)
   attr(:folder, :string, default: nil)
   attr(:tags, :list, default: [])
 
@@ -56,7 +57,14 @@ defmodule PhotoTaggerWeb.PhotoHTML do
           <li>
             <.link class={"#{folder.name == @folder && "font-bold"}"} href={build_url(folder.name, nil, [])}><%= folder.name %></.link>
             <ul class="list-disc list-inside">
-              <%= for tag <- folder.tags do %>
+              <%= for tag <- Enum.sort_by(folder.tags, fn tag ->
+                recommended_tags = Enum.map(@recommended_tags, & &1.name)
+                cond do
+                  tag in @tags -> 0 # Currently selected tags should appear first
+                  tag in recommended_tags -> 1 # followed by recommended tags
+                  true -> 2 # then all other tags
+                end
+              end) do %>
                 <li>
                   <.link class={"#{@folder == folder.name && tag in @tags && "font-bold"}"} href={build_url(folder.name, nil, [tag])}><%= tag %></.link>
                   <%= if @folder == folder.name do %>

--- a/app/lib/photo_tagger_web/controllers/photo_html/main.html.heex
+++ b/app/lib/photo_tagger_web/controllers/photo_html/main.html.heex
@@ -1,6 +1,6 @@
 <div class="grid grid-cols-7 gap-4 h-full">
   <div class="col-span-1 overflow-y-auto">
-    <.folders all_folders={@all_folders} all_tags={@all_tags} folder={@folder} tags={@tags} />
+    <.folders all_folders={@all_folders} all_tags={@all_tags} folder={@folder} tags={@tags} recommended_tags={@recommended_tags} />
   </div>
   <div class="col-span-4 overflow-y-auto">
     <.gallery photos={@filtered_photos} folder={@folder} tags={@tags} />

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,7 @@ services:
   dev_app:
     build: .
     ports:
-      - "4000:4000"
+      - 4001:4000
     volumes:
       - ./app:/app
     environment:
@@ -10,7 +10,7 @@ services:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_HOST=db
     depends_on:
-      - db
+      - dev_db
     working_dir: /app
     command: bash -c "mix setup && mix phx.server"
     # user: "1000:1000"
@@ -20,7 +20,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     volumes:
-    - "database:/var/lib/postgresql/data"
+    - dev_database:/var/lib/postgresql/data
 
 volumes:
   dev_database:


### PR DESCRIPTION
Resolves #2 

Makes add/remove tag buttons much more bold, and only show the add/rm button for recommended tags. (Adding a non-recommended tag would lead to an empty gallery anyway.)