### PR TITLE
Enable multiselect

### DIFF
--- a/app/assets/js/app.js
+++ b/app/assets/js/app.js
@@ -26,7 +26,15 @@ import "./scrollEvents.js"
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
-  params: {_csrf_token: csrfToken}
+  params: {_csrf_token: csrfToken},
+  metadata: {
+    click: (e, el) => {
+      return {
+        shift_key_pressed: e.shiftKey,
+        ctrl_key_pressed: e.ctrlKey,
+      }
+    }
+  }
 })
 
 // Show progress bar on live navigation and form submits

--- a/app/lib/photo_tagger_web/controllers/photo_controller.ex
+++ b/app/lib/photo_tagger_web/controllers/photo_controller.ex
@@ -5,15 +5,10 @@ defmodule PhotoTaggerWeb.PhotoController do
   alias PhotoTagger.Gallery
   alias PhotoTagger.Gallery.Photo
 
-  def build_url(folder, photo, tags, tail \\ nil) do
+  def build_url(folder, photo) do
     uri = URI.new!("/")
     uri = if(folder, do: URI.append_path(uri, "/folders/#{folder}"), else: uri)
     uri = if(photo, do: URI.append_path(uri, "/photos/#{photo.id}"), else: uri)
-    uri = if(tail, do: URI.append_path(uri, tail), else: uri)
-
-    query = Plug.Conn.Query.encode(%{query_tags: tags})
-    uri = if(!Enum.empty?(tags), do: URI.append_query(uri, query), else: uri)
-
     URI.to_string(uri)
   end
 
@@ -26,7 +21,7 @@ defmodule PhotoTaggerWeb.PhotoController do
     %{"folder" => folder, "images" => images} = photo_params
     results = Enum.map(images, fn image -> Gallery.create_photo(%{"folder" => folder, "image" => image}) end)
     if Enum.all?(results, fn {:ok, _} -> true; _ -> false end) do
-      url = build_url(folder, List.first(results) |> elem(1), [])
+      url = build_url(folder, List.first(results) |> elem(1))
       conn
       |> put_flash(:info, "Photos created successfully.")
       |> redirect(to: url)
@@ -34,7 +29,7 @@ defmodule PhotoTaggerWeb.PhotoController do
       successful_photos = for {:ok, photo} <- results, do: photo
       failed_photos = for {:error, changeset} <- results, do: changeset.changes.name
       #{Keyword.get(changeset.errors, :image) |> elem(0)}"
-      url = if(Enum.empty?(successful_photos), do: build_url(folder, nil, []), else: build_url(folder, List.first(successful_photos), []))
+      url = if(Enum.empty?(successful_photos), do: build_url(folder, nil), else: build_url(folder, List.first(successful_photos)))
       successful_photo_names = Enum.map(successful_photos, &(&1.name)) |> Enum.join(", ")
       conn = if(Enum.empty?(successful_photos), do: conn, else: conn |> put_flash(:info, "Some photos created successfully: #{successful_photo_names}"))
       conn

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -26,7 +26,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             <% [] -> %>
               <p class="text-center">Select a photo to view details</p>
             <% _ -> %>
-              <p class="text-center">Multiple photos selected!</p>
+              <.multi_photo_selection photos={@selected_photos} folder={@folder} tags={@tags} all_tags={@all_tags} recommended_tags={@recommended_tags} />
           <% end %>
         </div>
       </div>
@@ -339,6 +339,30 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         </.form>
       </:item>
     </.list>
+    """
+  end
+
+
+  attr(:photos, :list, required: true)
+  attr(:folder, :string, default: nil)
+  attr(:tags, :list, default: [])
+  attr(:all_tags, :list, required: true)
+  attr(:recommended_tags, :list, default: [])
+
+  def multi_photo_selection(assigns) do
+    ~H"""
+    <div>
+      <ul>
+        <%= for photo <- @photos do %>
+          <li>
+            <.link patch={build_url(@folder, [photo], @tags)}>
+              {photo.name}
+              <%!-- <img src={ImageUploader.url({photo.image, photo}, :small)} /> --%>
+            </.link>
+          </li>
+        <% end %>
+      </ul>
+    </div>
     """
   end
 

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -7,9 +7,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   alias PhotoTagger.Gallery.Photo
   alias PhotoTagger.Uploaders.ImageUploader
   alias PhotoTaggerWeb.HtmlHelpers
-  import PhotoTaggerWeb.PhotoController, only: [
-    build_url: 3,
-  ]
   import PhotoTaggerWeb.Components.Accordion
   import Logger
 
@@ -20,7 +17,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <.folders all_folders={@all_folders} all_tags={@all_tags} folder={@folder} tags={@tags} recommended_tags={@recommended_tags} />
         </div>
         <div id="gallery-section" class="col-span-4 overflow-y-auto">
-          <.gallery photos={@filtered_photos} folder={@folder} tags={@tags} />
+          <.gallery photos={@filtered_photos} folder={@folder} tags={@tags} selected_photo_ids={@selected_photo_ids}/>
         </div>
         <div id="photo-section" class="col-span-2 overflow-y-auto">
           <%= if @photo do %>
@@ -41,8 +38,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     folder = Map.get(params, "folder")
     tags = Map.get(params, "query_tags", [])
     photo_id = Map.get(params, "photo_id")
+    selected_photo_ids = Map.get(params, "selected_photos", [])
 
-    expanded_state = expand_state(%{folder: folder, tags: tags, photo_id: photo_id})
+    expanded_state = expand_state(%{folder: folder, tags: tags, photo_id: photo_id, selected_photo_ids: selected_photo_ids})
 
     # Reset scroll position of a section if the relevent params change
     socket = if(expanded_state.photo != Map.get(socket.assigns, :photo),
@@ -61,7 +59,21 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply, assign(socket, expanded_state)}
   end
 
-  def expand_state(%{folder: folder, tags: tags, photo_id: photo_id}) do
+  def build_url(folder, photo, tags, selected_photo_ids \\ []) do
+    uri = URI.new!("/")
+    uri = if(folder, do: URI.append_path(uri, "/folders/#{folder}"), else: uri)
+    uri = if(photo, do: URI.append_path(uri, "/photos/#{photo.id}"), else: uri)
+
+    tag_query = Plug.Conn.Query.encode(%{query_tags: tags})
+    uri = if(!Enum.empty?(tags), do: URI.append_query(uri, tag_query), else: uri)
+
+    selected_query = Plug.Conn.Query.encode(%{selected_photos: selected_photo_ids})
+    uri = if(!Enum.empty?(selected_photo_ids), do: URI.append_query(uri, selected_query), else: uri)
+
+    URI.to_string(uri)
+  end
+
+  def expand_state(%{folder: folder, tags: tags, photo_id: photo_id, selected_photo_ids: selected_photo_ids}) do
     filtered_photos =
       case {folder, tags} do
         {nil, []} -> Gallery.list_photos()
@@ -103,7 +115,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       photo: photo,
       filtered_photos: filtered_photos,
       recommended_tags: recommended_tags,
-      update_photo_form: update_photo_form
+      update_photo_form: update_photo_form,
+      selected_photo_ids: selected_photo_ids
     }
   end
 
@@ -131,7 +144,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     """
   end
 
-  defp folder_accordion_id(folder) do
+  def folder_accordion_id(folder) do
     if folder do
       HtmlHelpers.escape_html_id("accordion-#{folder}")
     else
@@ -208,20 +221,21 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:photos, :list, required: true)
   attr(:folder, :string, default: nil)
   attr(:tags, :list, default: [])
+  attr(:selected_photo_ids, :list, default: [])
 
   def gallery(assigns) do
     ~H"""
     <div>
-      <ul class="flex flex-wrap gap-4">
+      <ul class="flex flex-wrap gap-4 pt-6">
         <%= for photo <- @photos do %>
-          <li class="w-40 h-40">
-            <.link class="h-full" patch={build_url(@folder, photo, @tags)} >
+          <li class={"w-40 h-40 #{if(Enum.member?(@selected_photo_ids, to_string(photo.id)), do: "outline outline-4 outline-offset-2 outline-blue-400", else: "")}"}>
+            <button class={"h-full"} phx-click="select_gallery_photo" phx-value-photo_id={photo.id}>
               <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
               <img
                 class="w-40 h-40 object-cover"
                 src={ImageUploader.url({photo.image, photo}, :small)}
               />
-            </.link>
+            </button>
           </li>
         <% end %>
       </ul>
@@ -321,8 +335,36 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     folder = socket.assigns.folder
     tags = socket.assigns.tags
     photo_id = if(socket.assigns.photo, do: socket.assigns.photo.id, else: nil)
-    expanded_state = expand_state(%{folder: folder, tags: tags, photo_id: photo_id})
+    selected_photo_ids = socket.assigns.selected_photo_ids
+    expanded_state = expand_state(%{folder: folder, tags: tags, photo_id: photo_id, selected_photo_ids: selected_photo_ids})
     assign(socket, expanded_state)
+  end
+
+  # Holding ctrl while clicking a photo will select multiple
+  def handle_event("select_gallery_photo", %{"ctrl_key_pressed" => true, "photo_id" => photo_id}, socket) do
+    selected_photo_ids = Map.get(socket.assigns, :selected_photo_ids, [])
+    photo = socket.assigns.photo
+    case {selected_photo_ids, photo} do
+      # If no other photo is selected yet, select the photo as normal
+      {[], nil} -> handle_event("select_gallery_photo", %{"photo_id" => photo_id}, socket)
+      # If the photo is already selected, deselect it
+      {[], %Photo{id: ^photo_id}} -> {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, nil, socket.assigns.tags))}
+      # If this is the second photo selected, at both to the selected photos
+      {[], prev_photo} -> {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, nil, socket.assigns.tags, [prev_photo.id, photo_id]))}
+      # Otherwise, add or remove the new id to previous selections
+      {_, _} ->
+        new_selection = if(
+          Enum.member?(selected_photo_ids, photo_id),
+          do: Enum.filter(selected_photo_ids, & &1 != photo_id),
+          else: selected_photo_ids ++ [photo_id]
+        )
+        {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, nil, socket.assigns.tags, new_selection))}
+    end
+  end
+
+  def handle_event("select_gallery_photo", %{"photo_id" => photo_id}, socket) do
+    Logger.debug("Selecting photo: #{photo_id}")
+    {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, %{id: photo_id}, socket.assigns.tags))}
   end
 
   def handle_event("add_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -17,7 +17,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <.folders all_folders={@all_folders} all_tags={@all_tags} folder={@folder} tags={@tags} recommended_tags={@recommended_tags} />
         </div>
         <div id="gallery-section" class="col-span-4 overflow-y-auto">
-          <.gallery photos={@filtered_photos} folder={@folder} tags={@tags} selected_photos={@selected_photos}/>
+          <.gallery_nav_bar item_count={Enum.count(@filtered_photos)} multiselect_active={@multiselect_active} />
+          <div>
+            <.gallery photos={@filtered_photos} folder={@folder} tags={@tags} selected_photos={@selected_photos}/>
+          </div>
         </div>
         <div id="photo-section" class="col-span-2 overflow-y-auto">
           <%= case @selected_photos do %>
@@ -36,6 +39,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def mount(_params, _session, socket) do
     #TODO: I might be able to load all_tags and all_folders here instead of handle_params.
     # Would they be updated properly after getting forms to work with live_view?
+    socket = assign(socket, :multiselect_active, false)
     {:ok, socket}
   end
 
@@ -221,6 +225,33 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <.folder_nav_item current_folder={@folder} nav_folder={folder.name} nav_tags={folder.tags} recommended_tags={@recommended_tags} tags={@tags} />
         <% end %>
       </ul>
+    </div>
+    """
+  end
+
+  attr(:item_count, :integer, required: true)
+  attr(:multiselect_active, :boolean, required: true)
+
+  def gallery_nav_bar(assigns) do
+    button_colours = case assigns.multiselect_active do
+      false -> "border border-blue-600 text-blue-600 bg-white hover:bg-blue-100 hover:text-blue-800"
+      true -> "bg-blue-600 text-white hover:bg-blue-700"
+    end
+    ~H"""
+    <div class="flex items-center sticky top-0 bg-white">
+      <div class="flex-1"/>
+      <div class="flex-none pl-3 pr-3">
+        <button
+          class={"border rounded-full px-1 my-1 #{button_colours}"}
+          phx-click="toggle_multiselect">
+          <span class="pl-2 pr-2">
+            <.icon name="hero-squares-plus"/>
+          </span>
+        </button>
+      </div>
+      <div class="flex-none pl-3 pr-3 mr-4">
+        <p class="font-bold">{"#{@item_count} items"}</p>
+      </div>
     </div>
     """
   end
@@ -436,6 +467,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     end
     expanded_state = expand_state(%{folder: folder, tags: tags, photo_id: photo_id, selected_photo_ids: selected_photo_ids})
     assign(socket, expanded_state)
+  end
+
+  def handle_event("toggle_multiselect", _params, socket) do
+    {:noreply, assign(socket, :multiselect_active, !socket.assigns.multiselect_active)}
   end
 
   # Holding ctrl while clicking a photo will select multiple

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -17,11 +17,16 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <.folders all_folders={@all_folders} all_tags={@all_tags} folder={@folder} tags={@tags} recommended_tags={@recommended_tags} />
         </div>
         <div id="gallery-section" class="col-span-4 overflow-y-auto">
-          <.gallery photos={@filtered_photos} folder={@folder} tags={@tags} selected_photo_ids={@selected_photo_ids}/>
+          <.gallery photos={@filtered_photos} folder={@folder} tags={@tags} selected_photos={@selected_photos}/>
         </div>
         <div id="photo-section" class="col-span-2 overflow-y-auto">
-          <%= if @photo do %>
-            <.photo photo={@photo} folder={@folder} tags={@tags} recommended_tags={@recommended_tags} update_photo_form={@update_photo_form} />
+          <%= case @selected_photos do %>
+            <% [photo] -> %>
+              <.photo photo={photo} folder={@folder} tags={@tags} recommended_tags={@recommended_tags} update_photo_form={@update_photo_form} />
+            <% [] -> %>
+              <p class="text-center">Select a photo to view details</p>
+            <% _ -> %>
+              <p class="text-center">Multiple photos selected!</p>
           <% end %>
         </div>
       </div>
@@ -43,7 +48,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     expanded_state = expand_state(%{folder: folder, tags: tags, photo_id: photo_id, selected_photo_ids: selected_photo_ids})
 
     # Reset scroll position of a section if the relevent params change
-    socket = if(expanded_state.photo != Map.get(socket.assigns, :photo),
+    socket = if(expanded_state.selected_photos != Map.get(socket.assigns, :selected_photos),
       do: push_event(socket, "scroll_to_top", %{selector: "#photo-section"}),
       else: socket
     )
@@ -59,10 +64,15 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply, assign(socket, expanded_state)}
   end
 
-  def build_url(folder, photo, tags, selected_photo_ids \\ []) do
+  def build_url(folder, selected_photos, tags) do
+    {photo_id, selected_photo_ids} = case selected_photos do
+      [photo] -> {photo.id, []}
+      photos -> {nil, Enum.map(photos, &(&1.id))}
+    end
+
     uri = URI.new!("/")
     uri = if(folder, do: URI.append_path(uri, "/folders/#{folder}"), else: uri)
-    uri = if(photo, do: URI.append_path(uri, "/photos/#{photo.id}"), else: uri)
+    uri = if(photo_id, do: URI.append_path(uri, "/photos/#{photo_id}"), else: uri)
 
     tag_query = Plug.Conn.Query.encode(%{query_tags: tags})
     uri = if(!Enum.empty?(tags), do: URI.append_query(uri, tag_query), else: uri)
@@ -83,15 +93,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       end
     filtered_photos = Repo.preload(filtered_photos, :tags)
 
-    photo =
-      case photo_id do
-        nil ->
-          nil
-
-        id ->
-          p = Gallery.get_photo!(id)
-          Repo.preload(p, :tags)
-      end
+    selected_photos = [photo_id | selected_photo_ids]
+      |> Enum.filter(& &1 != nil)
+      |> Enum.map(& Gallery.get_photo!(&1))
+      |> Repo.preload(:tags)
 
     recommended_tags =
       Enum.reduce(filtered_photos, MapSet.new(), fn photo, acc ->
@@ -103,7 +108,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     all_folders = Gallery.list_folders_include_tags()
     all_tags = Gallery.list_tags()
 
-    update_photo_form = if(photo, do: photo, else: %Photo{})
+    update_photo_form = case selected_photos do
+        [photo] -> photo
+        _ -> %Photo{} # If no photos are selected, or many are, start form changeset from a blank photo struct
+      end
       |> Gallery.update_photo_changeset()
       |> Component.to_form()
 
@@ -112,16 +120,15 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       all_folders: all_folders,
       tags: tags,
       all_tags: all_tags,
-      photo: photo,
       filtered_photos: filtered_photos,
+      selected_photos: selected_photos,
       recommended_tags: recommended_tags,
       update_photo_form: update_photo_form,
-      selected_photo_ids: selected_photo_ids
     }
   end
 
   attr(:folder, :string, default: nil)
-  attr(:photo, Photo, default: nil)
+  attr(:selected_photos, :list, default: [])
   attr(:tags, :list, default: [])
   attr(:toggled_tag, :string, required: true)
   slot(:inner_block)
@@ -133,7 +140,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         assigns.toggled_tag in assigns.tags -> Enum.filter(assigns.tags, &(&1 != assigns.toggled_tag))
         true -> assigns.tags ++ [assigns.toggled_tag]
       end
-    assigns = assign(assigns, :href, build_url(assigns.folder, assigns.photo, tags_list))
+    assigns = assign(assigns, :href, build_url(assigns.folder, assigns.selected_photos, tags_list))
     ~H"""
       <.link class={"
         #{@toggled_tag in @tags && "font-bold"}
@@ -171,7 +178,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <:panel default_expanded={@is_current_folder}>
             <ul class="list-disc list-inside">
               <li>
-                <.link class={"#{Enum.empty?(@tags) && @is_current_folder && "font-bold"}"} patch={build_url(@nav_folder, nil, [])}>
+                <.link class={"#{Enum.empty?(@tags) && @is_current_folder && "font-bold"}"} patch={build_url(@nav_folder, [], [])}>
                   All photos
                 </.link>
               </li>
@@ -183,7 +190,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                 end
               end) do %>
                 <li >
-                  <.link class={"#{@is_current_folder && tag in @tags && "font-bold"}"} patch={build_url(@nav_folder, nil, [tag])}><%= tag %></.link>
+                  <.link class={"#{@is_current_folder && tag in @tags && "font-bold"}"} patch={build_url(@nav_folder, [], [tag])}><%= tag %></.link>
                   <%= if @is_current_folder and tag in @recommended_tag_names do %>
                       <.toggle_tag_button folder={@nav_folder} tags={@tags} toggled_tag={tag}><%= if(tag in @tags, do: "-", else: "+") %></.toggle_tag_button>
                     <% end %>
@@ -221,14 +228,14 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:photos, :list, required: true)
   attr(:folder, :string, default: nil)
   attr(:tags, :list, default: [])
-  attr(:selected_photo_ids, :list, default: [])
+  attr(:selected_photos, :list, default: [])
 
   def gallery(assigns) do
     ~H"""
     <div>
       <ul class="flex flex-wrap gap-4 pt-6">
         <%= for photo <- @photos do %>
-          <li class={"w-40 h-40 #{if(Enum.member?(@selected_photo_ids, to_string(photo.id)), do: "outline outline-4 outline-offset-2 outline-blue-400", else: "")}"}>
+          <li class={"w-40 h-40 #{if(Enum.member?(@selected_photos, photo), do: "outline outline-4 outline-offset-2 outline-blue-400", else: "")}"}>
             <button class={"h-full"} phx-click="select_gallery_photo" phx-value-photo_id={photo.id}>
               <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
               <img
@@ -247,6 +254,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:folder, :string, default: nil)
   attr(:tags, :list, default: [])
   attr(:recommended_tags, :list, default: [])
+  attr(:update_photo_form, :map, required: true)
 
   def photo(assigns) do
     ~H"""
@@ -257,13 +265,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         </.link>
       </:item>
       <:item title="Folder">
-        <.link class={"#{@folder == @photo.folder && "font-bold"}"} patch={build_url(@photo.folder, @photo, @tags)}><%= @photo.folder %></.link>
+        <.link class={"#{@folder == @photo.folder && "font-bold"}"} patch={build_url(@photo.folder, [@photo], @tags)}><%= @photo.folder %></.link>
       </:item>
       <:item title="Tags">
         <ul class="flex flex-wrap">
           <%= for tag <- @photo.tags do %>
             <li class="mr-2">
-              <.toggle_tag_button folder={@folder} photo={@photo} tags={@tags} toggled_tag={tag.name}><%= if(tag.name in @tags, do: "- ", else: "+ ") <> tag.name %></.toggle_tag_button>
+              <.toggle_tag_button folder={@folder} selected_photos={[@photo]} tags={@tags} toggled_tag={tag.name}><%= if(tag.name in @tags, do: "- ", else: "+ ") <> tag.name %></.toggle_tag_button>
               <.form class="inline" for={Component.to_form(%{"tag" => tag.name, "photo_id" => @photo.id})} phx-submit="remove_tag">
                 <input class="hidden" type="text" name="photo_id" value={@photo.id} />
                 <input class="hidden" type="text" name="tag" value={tag.name} />
@@ -337,37 +345,29 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def refresh_socket(socket) do
     folder = socket.assigns.folder
     tags = socket.assigns.tags
-    photo_id = if(socket.assigns.photo, do: socket.assigns.photo.id, else: nil)
-    selected_photo_ids = socket.assigns.selected_photo_ids
+    {photo_id, selected_photo_ids} = case socket.assigns.selected_photos do
+      [photo] -> {photo.id, []}
+      photos -> {nil, Enum.map(photos, &(&1.id))}
+    end
     expanded_state = expand_state(%{folder: folder, tags: tags, photo_id: photo_id, selected_photo_ids: selected_photo_ids})
     assign(socket, expanded_state)
   end
 
   # Holding ctrl while clicking a photo will select multiple
   def handle_event("select_gallery_photo", %{"ctrl_key_pressed" => true, "photo_id" => photo_id}, socket) do
-    selected_photo_ids = Map.get(socket.assigns, :selected_photo_ids, [])
-    photo = socket.assigns.photo
-    case {selected_photo_ids, photo} do
-      # If no other photo is selected yet, select the photo as normal
-      {[], nil} -> handle_event("select_gallery_photo", %{"photo_id" => photo_id}, socket)
-      # If the photo is already selected, deselect it
-      {[], %Photo{id: ^photo_id}} -> {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, nil, socket.assigns.tags))}
-      # If this is the second photo selected, at both to the selected photos
-      {[], prev_photo} -> {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, nil, socket.assigns.tags, [prev_photo.id, photo_id]))}
-      # Otherwise, add or remove the new id to previous selections
-      {_, _} ->
-        new_selection = if(
-          Enum.member?(selected_photo_ids, photo_id),
-          do: Enum.filter(selected_photo_ids, & &1 != photo_id),
-          else: selected_photo_ids ++ [photo_id]
-        )
-        {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, nil, socket.assigns.tags, new_selection))}
-    end
+    selected_photos = socket.assigns.selected_photos
+    # Remove the new photo from selected_photos if it is present, otherwise add it
+    new_selection = if(
+      Enum.any?(selected_photos, & to_string(&1.id) == photo_id),
+      do: Enum.filter(selected_photos, & to_string(&1.id) != photo_id),
+      else: [%{id: photo_id} | selected_photos]
+    )
+    {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, new_selection, socket.assigns.tags))}
   end
 
   def handle_event("select_gallery_photo", %{"photo_id" => photo_id}, socket) do
     Logger.debug("Selecting photo: #{photo_id}")
-    {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, %{id: photo_id}, socket.assigns.tags))}
+    {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, [%{id: photo_id}], socket.assigns.tags))}
   end
 
   def handle_event("add_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -240,6 +240,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
               <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
               <img
                 class="w-40 h-40 object-cover"
+                alt={photo.name}
                 src={ImageUploader.url({photo.image, photo}, :small)}
               />
             </button>
@@ -261,7 +262,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     <.list>
       <:item title="Image">
         <.link href={ImageUploader.url({@photo.image, @photo}, :original)} target="_blank">
-          <img src={ImageUploader.url({@photo.image, @photo}, :small)} />
+          <img img={@photo.name} src={ImageUploader.url({@photo.image, @photo}, :small)} />
         </.link>
       </:item>
       <:item title="Folder">
@@ -365,13 +366,17 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     ~H"""
     <.list>
       <:item title="Selected photos">
-        <ul>
+        <ul class="flex flex-wrap gap-2 p-2">
           <%= for photo <- @photos do %>
-            <li>
-              <.link patch={build_url(@folder, [photo], @tags)}>
-                {photo.name}
-                <%!-- <img src={ImageUploader.url({photo.image, photo}, :small)} /> --%>
-              </.link>
+            <li class={"w-20 h-20"}>
+              <button class={"h-full"} phx-click="select_gallery_photo" phx-value-photo_id={photo.id}>
+                <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
+                <img
+                  class="w-20 h-20 object-cover"
+                  alt={photo.name}
+                  src={ImageUploader.url({photo.image, photo}, :small)}
+                />
+              </button>
             </li>
           <% end %>
         </ul>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -233,7 +233,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def gallery(assigns) do
     ~H"""
     <div>
-      <ul class="flex flex-wrap gap-4 pt-6">
+      <ul class="flex flex-wrap gap-4 p-6">
         <%= for photo <- @photos do %>
           <li class={"w-40 h-40 #{if(Enum.member?(@selected_photos, photo), do: "outline outline-4 outline-offset-2 outline-blue-400", else: "")}"}>
             <button class={"h-full"} phx-click="select_gallery_photo" phx-value-photo_id={photo.id}>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -350,19 +350,75 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:recommended_tags, :list, default: [])
 
   def multi_photo_selection(assigns) do
+    {tags_to_add, tags_to_remove, tags_in_limbo} = Enum.reduce(assigns.all_tags, {[], [], []}, fn tag, {add, remove, limbo} ->
+      case Enum.reduce(assigns.photos, {0, 0}, fn photo, {has_tag_count, missing_count} ->
+        case tag in photo.tags do
+          true -> {has_tag_count + 1, missing_count}
+          false -> {has_tag_count, missing_count + 1}
+        end
+      end) do
+        {_, 0} -> {tag, [tag | remove], limbo} # All photos have this tag
+        {0, _} -> {[tag | add], remove, limbo} # No photos have this tag
+        _ -> {add, remove, [tag | limbo]} # Some photos have this tag
+      end
+    end)
     ~H"""
-    <div>
-      <ul>
-        <%= for photo <- @photos do %>
-          <li>
-            <.link patch={build_url(@folder, [photo], @tags)}>
-              {photo.name}
-              <%!-- <img src={ImageUploader.url({photo.image, photo}, :small)} /> --%>
-            </.link>
-          </li>
-        <% end %>
-      </ul>
-    </div>
+    <.list>
+      <:item title="Selected photos">
+        <ul>
+          <%= for photo <- @photos do %>
+            <li>
+              <.link patch={build_url(@folder, [photo], @tags)}>
+                {photo.name}
+                <%!-- <img src={ImageUploader.url({photo.image, photo}, :small)} /> --%>
+              </.link>
+            </li>
+          <% end %>
+        </ul>
+      </:item>
+      <:item title="Remove tags">
+        <ul class="flex flex-wrap">
+          <%= for tag <- (tags_to_remove ++ tags_in_limbo) do %>
+            <li class="mr-2">
+              <.form class="inline" for={Component.to_form(%{"tag" => tag.name})} phx-submit="remove_tag_bulk">
+                <input class="hidden" type="text" name="tag" value={tag.name} />
+                <button class="border border-red-600 rounded-full hover:bg-red-100 px-1 my-1 text-red-600 hover:text-red-800" type="submit"><%= tag.name %></button>
+              </.form>
+            </li>
+          <% end %>
+        </ul>
+      </:item>
+      <:item title="Add tags">
+        <div class="mt-4">
+          <.form for={Component.to_form(%{"tag" => ""})} phx-submit="add_tag_bulk">
+            <div class="flex items-center space-x-4">
+              <%!-- TODO: convert this simple inline form to a component --%>
+              <%!-- <.label for="add_any_tag">Add tag</.label> --%>
+              <input
+                type="text"
+                name="tag"
+                id="add_any_tag"
+                Placeholder="Add tag"
+                class="block max-w-64 rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6"
+              />
+              <.button type="submit">Submit</.button>
+            </div>
+          </.form>
+        </div>
+        <div class="flex flex-wrap mt-2">
+          <%= for tag <- @recommended_tags do %>
+            <%= if (tag not in tags_to_remove) do %>
+              <div class="mr-2">
+                <.form for={Component.to_form(%{"tag" => tag.name})} phx-submit="add_tag_bulk">
+                  <input class="hidden" type="text" name="tag" value={tag.name} />
+                  <button class="border border-blue-600 rounded-full hover:bg-blue-100 px-1 my-1 text-blue-600 hover:text-blue-800" type="submit"><%= tag.name %></button>
+                </.form>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </:item>
+    </.list>
     """
   end
 
@@ -403,6 +459,22 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def handle_event("remove_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
     photo = Gallery.get_photo!(photo_id)
     {:ok, _} = Gallery.remove_tag_from_photo(photo, tag)
+    {:noreply, refresh_socket(socket)}
+  end
+
+  def handle_event("add_tag_bulk", %{"tag" => tag}, socket) do
+    selected_photos = socket.assigns.selected_photos
+    Enum.each(selected_photos, fn photo ->
+      {:ok, _} = Gallery.add_tag_to_photo(photo, tag)
+    end)
+    {:noreply, refresh_socket(socket)}
+  end
+
+  def handle_event("remove_tag_bulk", %{"tag" => tag}, socket) do
+    selected_photos = socket.assigns.selected_photos
+    Enum.each(selected_photos, fn photo ->
+      {:ok, _} = Gallery.remove_tag_from_photo(photo, tag)
+    end)
     {:noreply, refresh_socket(socket)}
   end
 

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -474,7 +474,14 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   # Holding ctrl while clicking a photo will select multiple
-  def handle_event("select_gallery_photo", %{"ctrl_key_pressed" => true, "photo_id" => photo_id}, socket) do
+  def handle_event("select_gallery_photo", %{"ctrl_key_pressed" => ctrl_key_pressed, "photo_id" => photo_id}, socket) do
+    case {ctrl_key_pressed, socket.assigns.multiselect_active} do
+      {false, false} -> handle_single_photo_select(photo_id, socket)
+      _ -> handle_multi_photo_select(photo_id, socket)
+    end
+  end
+
+  def handle_multi_photo_select(photo_id, socket) do
     selected_photos = socket.assigns.selected_photos
     # Remove the new photo from selected_photos if it is present, otherwise add it
     new_selection = if(
@@ -485,8 +492,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, new_selection, socket.assigns.tags))}
   end
 
-  def handle_event("select_gallery_photo", %{"photo_id" => photo_id}, socket) do
-    Logger.debug("Selecting photo: #{photo_id}")
+  def handle_single_photo_select(photo_id, socket) do
     {:noreply, push_patch(socket, to: build_url(socket.assigns.folder, [%{id: photo_id}], socket.assigns.tags))}
   end
 


### PR DESCRIPTION
Resolves #20, #32 

Allows for selecting multiple photos, either by holding ctrl or by toggling multiselect mode.
When multiple photos selected, can add or remove tags from all of them at once.

Also adds highlighting of selected photos in gallery, and item count in gallery nav header.