### PR TITLE
Improve latency

### DIFF
--- a/app/lib/photo_tagger_web/components/accordion.ex
+++ b/app/lib/photo_tagger_web/components/accordion.ex
@@ -54,7 +54,7 @@ defmodule PhotoTaggerWeb.Components.Accordion do
           </button>
         </h3>
         <div
-          class="accordion-panel grid grid-rows-[0fr] data-[expanded]:grid-rows-[1fr] transition-all transform ease-in duration-100"
+          class="accordion-panel grid grid-rows-[0fr] data-[expanded]:grid-rows-[1fr]"
           data-expanded={panel[:default_expanded]}
           id={panel_id(@id, idx)}
           role="region"

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -423,9 +423,15 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     <div>
       <ul class="flex flex-wrap gap-4 p-6">
         <%= for photo <- @photos do %>
-          <li class="w-40 h-40 data-[selected]:outline outline-4 outline-offset-2 outline-blue-400"
-          data-selected={Enum.member?(@selected_photos, photo)}>
-            <button class="h-full" phx-click="select_gallery_photo" phx-value-photo_id={photo.id}>
+          <li class="w-40 h-40">
+            <button
+              class="h-full w-full
+                data-[selected]:outline outline-4 outline-offset-2 outline-blue-400
+                phx-click-loading:outline phx-click-loading:outline-blue-200"
+              data-selected={Enum.member?(@selected_photos, photo)}
+              phx-click="select_gallery_photo"
+              phx-value-photo_id={photo.id}
+            >
               <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
               <img
                 class="w-40 h-40 object-cover"

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -9,6 +9,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   alias PhotoTaggerWeb.HtmlHelpers
   import PhotoTaggerWeb.Components.Accordion
 
+  # require Logger
+
+
   def render(assigns) do
     ~H"""
     <div class="grid grid-cols-7 gap-4 h-full">
@@ -741,10 +744,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def handle_event("add_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
     photo = Gallery.get_photo!(photo_id)
     {:ok, _} = Gallery.add_tag_to_photo(photo, tag)
-
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
+     |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
      |> refresh_selected_photos()}
   end
@@ -756,6 +759,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
+     |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
      |> refresh_selected_photos()}
   end
@@ -770,6 +774,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
+     |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
      |> refresh_selected_photos()}
   end
@@ -784,6 +789,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
+     |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
      |> refresh_selected_photos()}
   end

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -11,7 +11,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
   # require Logger
 
-
   def render(assigns) do
     ~H"""
     <div class="grid grid-cols-7 gap-4 h-full">
@@ -265,10 +264,11 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
     ~H"""
     <.link
-      class={"
-        #{@toggled_tag in @tags && "font-bold"}
-        #{if(@toggled_tag in @tags, do: "bg-red-400 text-black hover:text-black", else: "bg-green-500 text-white hover:text-white")}
-        rounded-full px-1 no-underline"}
+      class={"rounded-full px-1 no-underline " <>
+        "bg-green-500 text-white hover:text-white " <> # styling if not in current filters
+        "data-[selected]:font-bold data-[selected]:bg-red-400 data-[selected]:text-black data-[selected]:hover:text-black" # styling if in current filters
+      }
+      data-selected={@toggled_tag in @tags}
       patch={@href}
     >
       {render_slot(@inner_block)}
@@ -300,7 +300,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     <li>
       <.accordion id={folder_accordion_id(@nav_folder)}>
         <:trigger>
-          <p class={"text-left #{@is_current_folder && "font-bold"}"}>
+          <p class="text-left data-[selected]:font-bold" data-selected={@is_current_folder}>
             {if(@nav_folder, do: @nav_folder, else: "All folders")}
           </p>
         </:trigger>
@@ -308,7 +308,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <ul class="list-disc list-inside">
             <li>
               <.link
-                class={"#{Enum.empty?(@tags) && @is_current_folder && "font-bold"}"}
+                class="data-[selected]:font-bold"
+                data-selected={Enum.empty?(@tags) && @is_current_folder}
                 patch={build_url(@nav_folder, [], [])}
               >
                 All photos
@@ -323,7 +324,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
               end) do %>
               <li>
                 <.link
-                  class={"#{@is_current_folder && tag in @tags && "font-bold"}"}
+                  class="data-[selected]:font-bold"
+                  data-selected={@is_current_folder && tag in @tags}
                   patch={build_url(@nav_folder, [], [tag])}
                 >
                   {tag}
@@ -393,7 +395,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       <div class="flex-1" />
       <div class="flex-none pl-3 pr-3">
         <button
-          class={"border rounded-full px-1 my-1 #{@button_colours}"}
+          class="border rounded-full px-1 my-1
+          border border-blue-600 text-blue-600 bg-white hover:bg-blue-100 hover:text-blue-800
+          aria-selected:bg-blue-600 aria-selected:text-white aria-selected:hover:bg-blue-700"
+          aria-selected={if(@multiselect_active, do: "true", else: "false")}
           phx-click="toggle_multiselect"
         >
           <span class="pl-2 pr-2">
@@ -418,7 +423,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     <div>
       <ul class="flex flex-wrap gap-4 p-6">
         <%= for photo <- @photos do %>
-          <li class={"w-40 h-40 #{if(Enum.member?(@selected_photos, photo), do: "outline outline-4 outline-offset-2 outline-blue-400", else: "")}"}>
+          <li class="w-40 h-40 data-[selected]:outline outline-4 outline-offset-2 outline-blue-400"
+          data-selected={Enum.member?(@selected_photos, photo)}>
             <button class="h-full" phx-click="select_gallery_photo" phx-value-photo_id={photo.id}>
               <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
               <img
@@ -450,8 +456,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       </:item>
       <:item title="Folder">
         <.link
-          class={"#{@folder == @photo.folder && "font-bold"}"}
+          class="data-[active]:font-bold"
           patch={build_url(@photo.folder, [@photo], @tags)}
+          data-active={@folder == @photo.folder}
         >
           {@photo.folder}
         </.link>
@@ -744,6 +751,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def handle_event("add_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
     photo = Gallery.get_photo!(photo_id)
     {:ok, _} = Gallery.add_tag_to_photo(photo, tag)
+
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -63,10 +63,11 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   def mount(_params, _session, socket) do
-    # TODO: I might be able to load all_tags and all_folders here instead of handle_params.
-    # Would they be updated properly after getting forms to work with live_view?
-    socket = assign(socket, :multiselect_active, false)
-    {:ok, socket}
+    {:ok,
+     socket
+     |> assign(:all_folders, Gallery.list_folders_include_tags())
+     |> assign(:all_tags, Gallery.list_tags())
+     |> assign(:multiselect_active, false)}
   end
 
   def handle_params(params, _session, socket) do
@@ -161,9 +162,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       |> MapSet.to_list()
       |> Enum.sort_by(&String.downcase(&1.name))
 
-    all_folders = Gallery.list_folders_include_tags()
-    all_tags = Gallery.list_tags()
-
     update_photo_form =
       case selected_photos do
         [photo] -> photo
@@ -175,9 +173,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
     %{
       folder: folder,
-      all_folders: all_folders,
       tags: tags,
-      all_tags: all_tags,
       filtered_photos: filtered_photos,
       selected_photos: selected_photos,
       recommended_tags: recommended_tags,
@@ -329,7 +325,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         true ->
           "bg-blue-600 text-white hover:bg-blue-700"
       end
+
     assigns = assign(assigns, :button_colours, button_colours)
+
     ~H"""
     <div class="flex items-center sticky top-0 bg-white">
       <div class="flex-1" />
@@ -530,6 +528,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           _ -> {add, remove, [tag | limbo]}
         end
       end)
+
     assigns = assign(assigns, :tags_to_add, tags_to_add)
     assigns = assign(assigns, :tags_to_remove, tags_to_remove)
     assigns = assign(assigns, :tags_in_limbo, tags_in_limbo)
@@ -633,22 +632,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     assign(socket, expanded_state)
   end
 
-  def handle_event("toggle_multiselect", _params, socket) do
-    {:noreply, assign(socket, :multiselect_active, !socket.assigns.multiselect_active)}
-  end
-
-  # Holding ctrl while clicking a photo will select multiple
-  def handle_event(
-        "select_gallery_photo",
-        %{"ctrl_key_pressed" => ctrl_key_pressed, "photo_id" => photo_id},
-        socket
-      ) do
-    case {ctrl_key_pressed, socket.assigns.multiselect_active} do
-      {false, false} -> handle_single_photo_select(photo_id, socket)
-      _ -> handle_multi_photo_select(photo_id, socket)
-    end
-  end
-
   def handle_multi_photo_select(photo_id, socket) do
     selected_photos = socket.assigns.selected_photos
     # Remove the new photo from selected_photos if it is present, otherwise add it
@@ -670,16 +653,42 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      )}
   end
 
+  ## Event Handlers
+
+  def handle_event("toggle_multiselect", _params, socket) do
+    {:noreply, assign(socket, :multiselect_active, !socket.assigns.multiselect_active)}
+  end
+
+  # Holding ctrl while clicking a photo will select multiple
+  def handle_event(
+        "select_gallery_photo",
+        %{"ctrl_key_pressed" => ctrl_key_pressed, "photo_id" => photo_id},
+        socket
+      ) do
+    case {ctrl_key_pressed, socket.assigns.multiselect_active} do
+      {false, false} -> handle_single_photo_select(photo_id, socket)
+      _ -> handle_multi_photo_select(photo_id, socket)
+    end
+  end
+
   def handle_event("add_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
     photo = Gallery.get_photo!(photo_id)
     {:ok, _} = Gallery.add_tag_to_photo(photo, tag)
-    {:noreply, refresh_socket(socket)}
+
+    {:noreply,
+     socket
+     |> assign(:all_tags, Gallery.list_tags())
+     |> refresh_socket()}
   end
 
   def handle_event("remove_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
     photo = Gallery.get_photo!(photo_id)
     {:ok, _} = Gallery.remove_tag_from_photo(photo, tag)
-    {:noreply, refresh_socket(socket)}
+
+    {:noreply,
+     socket
+     |> assign(:all_tags, Gallery.list_tags())
+     |> refresh_socket()}
   end
 
   def handle_event("add_tag_bulk", %{"tag" => tag}, socket) do
@@ -689,7 +698,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       {:ok, _} = Gallery.add_tag_to_photo(photo, tag)
     end)
 
-    {:noreply, refresh_socket(socket)}
+    {:noreply,
+     socket
+     |> assign(:all_tags, Gallery.list_tags())
+     |> refresh_socket()}
   end
 
   def handle_event("remove_tag_bulk", %{"tag" => tag}, socket) do
@@ -699,16 +711,21 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       {:ok, _} = Gallery.remove_tag_from_photo(photo, tag)
     end)
 
-    {:noreply, refresh_socket(socket)}
+    {:noreply,
+     socket
+     |> assign(:all_tags, Gallery.list_tags())
+     |> refresh_socket()}
   end
 
   def handle_event("update_photo", %{"photo_id" => id, "photo" => photo_params}, socket) do
     photo = Gallery.get_photo!(id)
+    result = Gallery.update_photo(photo, photo_params)
 
-    case Gallery.update_photo(photo, photo_params) do
+    case result do
       {:ok, _photo} ->
         {:noreply,
-         refresh_socket(socket)
+         assign(socket, :all_folders, Gallery.list_folders_include_tags())
+         |> refresh_socket()
          |> put_flash(:info, "Photo updated successfully.")}
 
       {:error, failed_op, failed_value, _changeset} ->
@@ -726,7 +743,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:ok, _photo} = Gallery.delete_photo(photo)
 
     {:noreply,
-     push_patch(socket, to: build_url(socket.assigns.folder, nil, socket.assigns.tags))
+     socket
+     |> assign(:all_folders, Gallery.list_folders_include_tags())
+     |> assign(:all_tags, Gallery.list_tags())
+     |> push_patch(to: build_url(socket.assigns.folder, nil, socket.assigns.tags))
      |> put_flash(:info, "Photo deleted successfully.")}
   end
 end

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -710,6 +710,16 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      )}
   end
 
+  def refresh_selected_photos(socket) do
+    selected_photo_ids = socket.assigns.selected_photos |> Enum.map(& &1.id)
+
+    selected_photos =
+      Enum.map(selected_photo_ids, &Gallery.get_photo!(&1))
+      |> Repo.preload(:tags)
+
+    assign(socket, selected_photos: selected_photos)
+  end
+
   ## Event Handlers
 
   def handle_event("toggle_multiselect", _params, socket) do
@@ -735,7 +745,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
-     |> refresh_socket()}
+     |> refresh_socket()
+     |> refresh_selected_photos()}
   end
 
   def handle_event("remove_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
@@ -745,7 +756,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
-     |> refresh_socket()}
+     |> refresh_socket()
+     |> refresh_selected_photos()}
   end
 
   def handle_event("add_tag_bulk", %{"tag" => tag}, socket) do
@@ -758,7 +770,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
-     |> refresh_socket()}
+     |> refresh_socket()
+     |> refresh_selected_photos()}
   end
 
   def handle_event("remove_tag_bulk", %{"tag" => tag}, socket) do
@@ -771,7 +784,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply,
      socket
      |> assign(:all_tags, Gallery.list_tags())
-     |> refresh_socket()}
+     |> refresh_socket()
+     |> refresh_selected_photos()}
   end
 
   def handle_event("update_photo", %{"photo_id" => id, "photo" => photo_params}, socket) do
@@ -783,6 +797,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         {:noreply,
          assign(socket, :all_folders, Gallery.list_folders_include_tags())
          |> refresh_socket()
+         |> refresh_selected_photos()
          |> put_flash(:info, "Photo updated successfully.")}
 
       {:error, failed_op, failed_value, _changeset} ->

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -8,7 +8,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   alias PhotoTagger.Uploaders.ImageUploader
   alias PhotoTaggerWeb.HtmlHelpers
   import PhotoTaggerWeb.Components.Accordion
-  import Logger
 
   def render(assigns) do
     ~H"""
@@ -63,11 +62,21 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   def mount(_params, _session, socket) do
-    {:ok,
-     socket
-     |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> assign(:all_tags, Gallery.list_tags())
-     |> assign(:multiselect_active, false)}
+    {
+      :ok,
+      socket
+      |> assign(:all_folders, Gallery.list_folders_include_tags())
+      |> assign(:all_tags, Gallery.list_tags())
+      |> assign(:multiselect_active, false)
+      #  |> assign(%{
+      #    folder: nil,
+      #    tags: [],
+      #    filtered_photos: [],
+      #    selected_photos: [],
+      #    recommended_tags: [],
+      #    update_photo_form: Gallery.update_photo_changeset(%Photo{}) |> Component.to_form()
+      #  })
+    }
   end
 
   def handle_params(params, _session, socket) do
@@ -77,7 +86,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     selected_photo_ids = Map.get(params, "selected_photos", [])
 
     expanded_state =
-      expand_state(%{
+      expand_state(socket, %{
         folder: folder,
         tags: tags,
         photo_id: photo_id,
@@ -133,34 +142,82 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     URI.to_string(uri)
   end
 
-  def expand_state(%{
-        folder: folder,
-        tags: tags,
-        photo_id: photo_id,
-        selected_photo_ids: selected_photo_ids
-      }) do
+  def expand_state(
+        socket,
+        %{
+          folder: folder,
+          tags: tags,
+          # This id comes from the url path
+          photo_id: photo_id,
+          # These come from url query params
+          selected_photo_ids: selected_photo_ids
+        }
+      ) do
+    prev_folder = Map.get(socket.assigns, :folder)
+    prev_tags = Map.get(socket.assigns, :tags, [])
+    prev_filtered_photos = Map.get(socket.assigns, :filtered_photos, nil)
+
     filtered_photos =
-      case {folder, tags} do
-        {nil, []} -> Gallery.list_photos()
-        {nil, tags} -> Gallery.list_photos_by_all_tags(tags)
-        {folder, []} -> Gallery.list_photos_by_folder(folder)
-        {folder, tags} -> Gallery.list_photos_by_folder_and_tags(folder, tags)
+      case {folder, tags, prev_filtered_photos} do
+        # If the folder and tags are unchanged, and we have previously cached filtered photos, use them without querying the database
+        {^prev_folder, ^prev_tags, prev_filtered_photos} when is_list(prev_filtered_photos) ->
+          prev_filtered_photos
+
+        {nil, [], _} ->
+          Gallery.list_photos()
+          |> Repo.preload(:tags)
+
+        {nil, tags, _} ->
+          Gallery.list_photos_by_all_tags(tags)
+          |> Repo.preload(:tags)
+
+        {folder, [], _} ->
+          Gallery.list_photos_by_folder(folder)
+          |> Repo.preload(:tags)
+
+        {folder, tags, _} ->
+          Gallery.list_photos_by_folder_and_tags(folder, tags)
+          |> Repo.preload(:tags)
       end
 
-    filtered_photos = Repo.preload(filtered_photos, :tags)
+    prev_selected_photos = Map.get(socket.assigns, :selected_photos, nil)
 
-    selected_photos =
+    prev_selected_photo_ids =
+      case Map.get(socket.assigns, :selected_photos, nil) do
+        nil -> nil
+        photos -> Enum.map(photos, & &1.id)
+      end
+
+    new_selected_photo_ids =
       [photo_id | selected_photo_ids]
       |> Enum.filter(&(&1 != nil))
-      |> Enum.map(&Gallery.get_photo!(&1))
-      |> Repo.preload(:tags)
 
+    selected_photos =
+      case {new_selected_photo_ids, prev_selected_photos} do
+        # If the selected photo ids have not changed, and we have cached selected photos, use them without querying the database
+        {^prev_selected_photo_ids, prev_selected_photos} when is_list(prev_selected_photos) ->
+          prev_selected_photos
+
+        # Otherwise, selections have changed, query them from the database
+        {_, _} ->
+          new_selected_photo_ids
+          |> Enum.map(&Gallery.get_photo!(&1))
+          |> Repo.preload(:tags)
+      end
+
+    # If filtered photos have not changed, use cached recommended tags
     recommended_tags =
-      Enum.reduce(filtered_photos, MapSet.new(), fn photo, acc ->
-        MapSet.union(acc, MapSet.new(photo.tags))
-      end)
-      |> MapSet.to_list()
-      |> Enum.sort_by(&String.downcase(&1.name))
+      case filtered_photos do
+        ^prev_filtered_photos ->
+          Map.get(socket.assigns, :recommended_tags, [])
+
+        _ ->
+          Enum.reduce(filtered_photos, MapSet.new(), fn photo, acc ->
+            MapSet.union(acc, MapSet.new(photo.tags))
+          end)
+          |> MapSet.to_list()
+          |> Enum.sort_by(&String.downcase(&1.name))
+      end
 
     update_photo_form =
       case selected_photos do
@@ -622,7 +679,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       end
 
     expanded_state =
-      expand_state(%{
+      expand_state(socket, %{
         folder: folder,
         tags: tags,
         photo_id: photo_id,


### PR DESCRIPTION
Resolves #70

In event handling and handle_params, attempt to use cached variables whenever possible - only refresh socket variables when they may have changed. This is an attempt to speed up liveview lifecycles, although I'm unsure how effective it is since DB queries seem to only take a handful of milliseconds. Also adds a loading-state to the gallery photo select border, to give a better impression of responsiveness while requests to the server are in progress.