### PR TITLE
Adds group field, and collapsing groups

### DIFF
--- a/app/lib/photo_tagger/gallery/photo.ex
+++ b/app/lib/photo_tagger/gallery/photo.ex
@@ -12,6 +12,7 @@ defmodule PhotoTagger.Gallery.Photo do
     field :description, :string
     field :notes, :string
     field :image_last_modified, :utc_datetime
+    field :group, :string
 
     timestamps(type: :utc_datetime)
 
@@ -24,7 +25,7 @@ defmodule PhotoTagger.Gallery.Photo do
   @doc false
   def changeset_create(photo, attrs) do
     photo
-    |> cast(attrs, [:name, :folder, :description, :notes, :image_last_modified])
+    |> cast(attrs, [:name, :folder, :description, :notes, :image_last_modified, :group])
     |> cast_attachments(attrs, [:image], allow_urls: true)
     |> validate_required([:name, :folder, :image, :image_last_modified])
     |> unique_constraint([:name, :folder])
@@ -32,7 +33,7 @@ defmodule PhotoTagger.Gallery.Photo do
 
   def changeset_update(photo, attrs) do
     photo
-    |> cast(attrs, [:name, :image, :folder, :description, :notes])
+    |> cast(attrs, [:name, :image, :folder, :description, :notes, :group])
     |> unique_constraint([:name, :folder])
   end
 end

--- a/app/lib/photo_tagger_web/components/core_components.ex
+++ b/app/lib/photo_tagger_web/components/core_components.ex
@@ -246,6 +246,30 @@ defmodule PhotoTaggerWeb.CoreComponents do
     """
   end
 
+  attr :selected, :boolean, required: true
+  attr :class, :string, default: nil
+  attr :rest, :global, include: ~w(disabled form name value)
+  slot :inner_block, required: true
+
+  def toggle_button(assigns) do
+    ~H"""
+    <button
+      class={
+        ClassHelper.tw([
+          "border rounded-full px-1 my-1",
+          "border border-blue-600 text-blue-600 bg-white hover:bg-blue-100 hover:text-blue-800",
+          "aria-selected:bg-blue-600 aria-selected:text-white aria-selected:hover:bg-blue-700",
+          @class
+        ])
+      }
+      aria-selected={if(@selected, do: "true", else: "false")}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </button>
+    """
+  end
+
   @doc """
   Renders an input with label and error messages.
 

--- a/app/lib/photo_tagger_web/controllers/photo_controller.ex
+++ b/app/lib/photo_tagger_web/controllers/photo_controller.ex
@@ -18,19 +18,22 @@ defmodule PhotoTaggerWeb.PhotoController do
   end
 
   def create(conn, %{"photo" => photo_params}) do
-    %{"folder" => folder, "images" => images, "file_metadata" => metadata_string} = photo_params
+    {%{"images" => images, "file_metadata" => metadata_string}, other_params} =
+      Map.split(photo_params, ["images", "file_metadata"])
+
     metadata = JSON.decode!(metadata_string)
+    folder = other_params["folder"]
 
     photo_attrs =
       Enum.map(images, fn image ->
-        %{
-          "folder" => folder,
-          "image" => image,
-          "image_last_modified" =>
-            Enum.find(metadata, &(&1["name"] == image.filename))
-            |> Map.get("lastModified")
-            |> DateTime.from_unix!(:millisecond)
-        }
+        other_params
+        |> Map.put("image", image)
+        |> Map.put(
+          "image_last_modified",
+          Enum.find(metadata, &(&1["name"] == image.filename))
+          |> Map.get("lastModified")
+          |> DateTime.from_unix!(:millisecond)
+        )
       end)
 
     results = Enum.map(photo_attrs, &Gallery.create_photo(&1))

--- a/app/lib/photo_tagger_web/controllers/photo_html/new_photo_form.html.heex
+++ b/app/lib/photo_tagger_web/controllers/photo_html/new_photo_form.html.heex
@@ -5,6 +5,7 @@
   <%!-- <.input field={f[:name]} type="text" label="Name" /> --%>
   <.input field={f[:folder]} type="text" label="Folder" required />
   <.input field={f[:images]} type="file" label="Image" multiple required />
+  <.input field={f[:group]} type="text" label="Group"/>
   <input class="hidden" type="text" name="photo[file_metadata]" id="new_photo_form_file_metadata" />
   <%!-- <.input
     field={f[:tags]}

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -90,6 +90,17 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     photo_id = Map.get(params, "photo_id")
     selected_photo_ids = Map.get(params, "selected_photos", [])
 
+    collapse_groups =
+      Map.get(params, "collapse_groups", nil)
+      |> case do
+        nil -> socket.assigns.collapse_groups # use the current value if not set in the url
+        false -> false
+        "false" -> false
+        _ -> true
+      end
+
+    socket = assign(socket, :collapse_groups, collapse_groups)
+
     expanded_state =
       expand_state(socket, %{
         folder: folder,
@@ -125,7 +136,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply, assign(socket, expanded_state)}
   end
 
-  def build_url(folder, selected_photos, tags) do
+  def build_url(folder, selected_photos, tags, other_queries \\ %{}) do
     {photo_id, selected_photo_ids} =
       case selected_photos do
         [photo] -> {photo.id, []}
@@ -136,13 +147,21 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     uri = if(folder, do: URI.append_path(uri, "/folders/#{folder}"), else: uri)
     uri = if(photo_id, do: URI.append_path(uri, "/photos/#{photo_id}"), else: uri)
 
-    tag_query = Plug.Conn.Query.encode(%{query_tags: tags})
-    uri = if(!Enum.empty?(tags), do: URI.append_query(uri, tag_query), else: uri)
+    # Don't include queries with values of "false" in the URL
+    # other_queries = Map.filter(other_queries, fn {_, v} -> v != false end)
 
-    selected_query = Plug.Conn.Query.encode(%{selected_photos: selected_photo_ids})
+    query =
+      %{}
+      |> Map.put(:query_tags, tags)
+      |> Map.put(:selected_photos, selected_photo_ids)
+      |> Map.merge(other_queries)
+      |> Plug.Conn.Query.encode()
 
     uri =
-      if(!Enum.empty?(selected_photo_ids), do: URI.append_query(uri, selected_query), else: uri)
+      case query do
+        "" -> uri
+        _ -> URI.append_query(uri, query)
+      end
 
     URI.to_string(uri)
   end
@@ -428,6 +447,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def gallery(assigns) do
     grouped_photos = Enum.group_by(assigns.photos, & &1.group)
     assigns = assign(assigns, :grouped_photos, grouped_photos)
+
+    Logger.debug("collapse groups: #{inspect(assigns.collapse_groups)}")
 
     assigns =
       case assigns.collapse_groups do
@@ -723,27 +744,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     """
   end
 
-  def refresh_socket(socket) do
-    folder = socket.assigns.folder
-    tags = socket.assigns.tags
-
-    {photo_id, selected_photo_ids} =
-      case socket.assigns.selected_photos do
-        [photo] -> {photo.id, []}
-        photos -> {nil, Enum.map(photos, & &1.id)}
-      end
-
-    expanded_state =
-      expand_state(socket, %{
-        folder: folder,
-        tags: tags,
-        photo_id: photo_id,
-        selected_photo_ids: selected_photo_ids
-      })
-
-    assign(socket, expanded_state)
-  end
-
   def handle_multi_photo_select(photo_id, socket) do
     selected_photos = socket.assigns.selected_photos
     # Remove the new photo from selected_photos if it is present, otherwise add it
@@ -782,7 +782,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   def handle_event("toggle_collapse_groups", _params, socket) do
-    {:noreply, assign(socket, :collapse_groups, !socket.assigns.collapse_groups)}
+    {:noreply,
+     push_patch(socket,
+       to:
+         build_url(socket.assigns.folder, socket.assigns.selected_photos, socket.assigns.tags, %{
+           collapse_groups: !socket.assigns.collapse_groups
+         })
+     )}
   end
 
   # Holding ctrl while clicking a photo will select multiple
@@ -802,7 +808,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         %{"photo_group" => photo_group, "ctrl_key_pressed" => ctrl_key_pressed},
         socket
       ) do
-    # TODO implement, then group field in multiselect mode form, then add collapsed to url
     group_photos = Enum.filter(socket.assigns.filtered_photos, &(&1.group == photo_group))
 
     group_already_selected =
@@ -832,7 +837,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -844,7 +848,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -859,7 +862,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -874,7 +876,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -886,13 +887,12 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       {:ok, _photo} ->
         {:noreply,
          assign(socket, :all_folders, Gallery.list_folders_include_tags())
-         |> refresh_socket()
          |> refresh_selected_photos()
          |> put_flash(:info, "Photo updated successfully.")}
 
       {:error, failed_op, failed_value, _changeset} ->
         {:noreply,
-         refresh_socket(socket)
+         socket
          |> put_flash(
            :error,
            "Failed to update photo. Error #{failed_value} in step #{failed_op}."

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -750,27 +750,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     """
   end
 
-  def refresh_socket(socket) do
-    folder = socket.assigns.folder
-    tags = socket.assigns.tags
-
-    {photo_id, selected_photo_ids} =
-      case socket.assigns.selected_photos do
-        [photo] -> {photo.id, []}
-        photos -> {nil, Enum.map(photos, & &1.id)}
-      end
-
-    expanded_state =
-      expand_state(socket, %{
-        folder: folder,
-        tags: tags,
-        photo_id: photo_id,
-        selected_photo_ids: selected_photo_ids
-      })
-
-    assign(socket, expanded_state)
-  end
-
   def handle_multi_photo_select(photo_id, socket) do
     selected_photos = socket.assigns.selected_photos
     # Remove the new photo from selected_photos if it is present, otherwise add it
@@ -792,13 +771,17 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      )}
   end
 
-  def refresh_photos(socket) do
+  def refresh_selected_photos(socket) do
     selected_photos =
       socket.assigns.selected_photos
       |> Enum.map(& &1.id)
       |> Enum.map(&Gallery.get_photo!(&1))
       |> Repo.preload(:tags)
 
+    assign(socket, selected_photos: selected_photos)
+  end
+
+  def refresh_filtered_photos(socket) do
     filtered_photos =
       case {socket.assigns.folder, socket.assigns.tags} do
         {nil, []} -> Gallery.list_photos()
@@ -808,9 +791,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       end
       |> Repo.preload(:tags)
 
-    socket
-    |> assign(selected_photos: selected_photos)
-    |> assign(filtered_photos: filtered_photos)
+    assign(socket, filtered_photos: filtered_photos)
   end
 
   ## Event Handlers
@@ -870,8 +851,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
-     |> refresh_photos()}
+     |> refresh_selected_photos()}
   end
 
   def handle_event("remove_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
@@ -882,8 +862,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
-     |> refresh_photos()}
+     |> refresh_selected_photos()}
   end
 
   def handle_event("add_tag_bulk", %{"tag" => tag}, socket) do
@@ -897,8 +876,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
-     |> refresh_photos()}
+     |> refresh_selected_photos()}
   end
 
   def handle_event("remove_tag_bulk", %{"tag" => tag}, socket) do
@@ -912,8 +890,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
-     |> refresh_socket()
-     |> refresh_photos()}
+     |> refresh_selected_photos()}
   end
 
   def handle_event("set_group_bulk", %{"group" => group}, socket) do
@@ -923,7 +900,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       {:ok, _} = Gallery.update_photo(photo, %{"group" => group})
     end)
 
-    {:noreply, refresh_photos(socket)}
+    {:noreply,
+     socket
+     |> refresh_selected_photos()
+     |> refresh_filtered_photos()}
   end
 
   def handle_event("update_photo", %{"photo_id" => id, "photo" => photo_params}, socket) do
@@ -934,13 +914,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       {:ok, _photo} ->
         {:noreply,
          assign(socket, :all_folders, Gallery.list_folders_include_tags())
-         |> refresh_socket()
-         |> refresh_photos()
+         |> refresh_selected_photos()
          |> put_flash(:info, "Photo updated successfully.")}
 
       {:error, failed_op, failed_value, _changeset} ->
         {:noreply,
-         refresh_socket(socket)
+         socket
+         |> refresh_selected_photos()
          |> put_flash(
            :error,
            "Failed to update photo. Error #{failed_value} in step #{failed_op}."

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -425,6 +425,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <%= for photo <- @photos do %>
           <li class="w-40 h-40">
             <button
+              id={"gallery-photo-button-#{photo.id}"}
               class="h-full w-full
                 data-[selected]:outline outline-4 outline-offset-2 outline-blue-400
                 phx-click-loading:outline phx-click-loading:outline-blue-200"
@@ -557,6 +558,12 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             name="photo[description]"
             type="textarea"
             label="Description"
+          />
+          <.input
+            field={@update_photo_form[:group]}
+            name="photo[group]"
+            type="text"
+            label="Group"
           />
           <.button class="mt-4">Save</.button>
         </.form>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -35,6 +35,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             folder={@folder}
             tags={@tags}
             selected_photos={@selected_photos}
+            collapse_groups={@collapse_groups}
           />
         </div>
       </div>
@@ -422,21 +423,43 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:folder, :string, default: nil)
   attr(:tags, :list, default: [])
   attr(:selected_photos, :list, default: [])
+  attr(:collapse_groups, :boolean, default: false)
 
   def gallery(assigns) do
+    grouped_photos = Enum.group_by(assigns.photos, & &1.group)
+    assigns = assign(assigns, :grouped_photos, grouped_photos)
+
+    assigns =
+      case assigns.collapse_groups do
+        false ->
+          assigns
+
+        true ->
+          assign(
+            assigns,
+            :photos,
+            # Filter out photos that are in a group, excepting the first in any group
+            Enum.filter(assigns.photos, fn photo ->
+              photo.group == nil or photo == List.first(grouped_photos[photo.group])
+            end)
+          )
+      end
+
     ~H"""
     <div>
       <ul class="flex flex-wrap gap-4 p-6">
         <%= for photo <- @photos do %>
+          <% represents_group = @collapse_groups and photo.group != nil and Enum.count(@grouped_photos[photo.group]) > 1 %>
           <li class="w-40 h-40">
             <button
               id={"gallery-photo-button-#{photo.id}"}
-              class="h-full w-full
+              class="h-full w-full relative
                 data-[selected]:outline outline-4 outline-offset-2 outline-blue-400
                 phx-click-loading:outline phx-click-loading:outline-blue-200"
               data-selected={Enum.member?(@selected_photos, photo)}
-              phx-click="select_gallery_photo"
+              phx-click={if(represents_group, do: "select_gallery_group", else: "select_gallery_photo")}
               phx-value-photo_id={photo.id}
+              phx-value-photo_group={photo.group}
             >
               <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
               <img
@@ -444,6 +467,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                 alt={photo.name}
                 src={ImageUploader.url({photo.image, photo}, :small)}
               />
+              <%= if represents_group do %>
+                <div class="w-40 h-40 -z-10 absolute left-1 bottom-1 bg-gray-500" />
+                <div class="w-40 h-40 -z-20 absolute left-2 bottom-2 bg-gray-400" />
+              <% end %>
             </button>
           </li>
         <% end %>
@@ -768,6 +795,33 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       {false, false} -> handle_single_photo_select(photo_id, socket)
       _ -> handle_multi_photo_select(photo_id, socket)
     end
+  end
+
+  def handle_event(
+        "select_gallery_group",
+        %{"photo_group" => photo_group, "ctrl_key_pressed" => ctrl_key_pressed},
+        socket
+      ) do
+    # TODO implement, then group field in multiselect mode form, then add collapsed to url
+    group_photos = Enum.filter(socket.assigns.filtered_photos, &(&1.group == photo_group))
+
+    group_already_selected =
+      Enum.all?(group_photos, &Enum.member?(socket.assigns.selected_photos, &1))
+
+    # If not in multiselect mode, select all photos in the group
+    # If in multiselect mode, and all photos in the group are already selected, remove them from the selection
+    # If in multiselect mode, and some or no photos in the group are already selected, add all of them to the selection
+    new_selected_photos =
+      case {ctrl_key_pressed, socket.assigns.multiselect_active, group_already_selected} do
+        {false, false, _} -> group_photos
+        {_, _, true} -> Enum.filter(socket.assigns.selected_photos, &(&1.group != photo_group))
+        {_, _, false} -> Enum.concat(socket.assigns.selected_photos, group_photos) |> Enum.uniq()
+      end
+
+    {:noreply,
+     push_patch(socket,
+       to: build_url(socket.assigns.folder, new_selected_photos, socket.assigns.tags)
+     )}
   end
 
   def handle_event("add_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -394,17 +394,15 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     <div class="flex items-center sticky top-0 bg-white">
       <div class="flex-1" />
       <div class="flex-none pl-3 pr-3">
-        <button
-          class="border rounded-full px-1 my-1
-          border border-blue-600 text-blue-600 bg-white hover:bg-blue-100 hover:text-blue-800
-          aria-selected:bg-blue-600 aria-selected:text-white aria-selected:hover:bg-blue-700"
-          aria-selected={if(@multiselect_active, do: "true", else: "false")}
+        <.toggle_button
+          selected={@multiselect_active}
           phx-click="toggle_multiselect"
         >
           <span class="pl-2 pr-2">
             <.icon name="hero-squares-plus" />
+            Multiselect
           </span>
-        </button>
+        </.toggle_button>
       </div>
       <div class="flex-none pl-3 pr-3 mr-4">
         <p class="font-bold">{"#{@item_count} items"}</p>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -90,17 +90,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     photo_id = Map.get(params, "photo_id")
     selected_photo_ids = Map.get(params, "selected_photos", [])
 
-    collapse_groups =
-      Map.get(params, "collapse_groups", nil)
-      |> case do
-        nil -> socket.assigns.collapse_groups # use the current value if not set in the url
-        false -> false
-        "false" -> false
-        _ -> true
-      end
-
-    socket = assign(socket, :collapse_groups, collapse_groups)
-
     expanded_state =
       expand_state(socket, %{
         folder: folder,
@@ -136,7 +125,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     {:noreply, assign(socket, expanded_state)}
   end
 
-  def build_url(folder, selected_photos, tags, other_queries \\ %{}) do
+  def build_url(folder, selected_photos, tags) do
     {photo_id, selected_photo_ids} =
       case selected_photos do
         [photo] -> {photo.id, []}
@@ -147,21 +136,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     uri = if(folder, do: URI.append_path(uri, "/folders/#{folder}"), else: uri)
     uri = if(photo_id, do: URI.append_path(uri, "/photos/#{photo_id}"), else: uri)
 
-    # Don't include queries with values of "false" in the URL
-    # other_queries = Map.filter(other_queries, fn {_, v} -> v != false end)
+    tag_query = Plug.Conn.Query.encode(%{query_tags: tags})
+    uri = if(!Enum.empty?(tags), do: URI.append_query(uri, tag_query), else: uri)
 
-    query =
-      %{}
-      |> Map.put(:query_tags, tags)
-      |> Map.put(:selected_photos, selected_photo_ids)
-      |> Map.merge(other_queries)
-      |> Plug.Conn.Query.encode()
+    selected_query = Plug.Conn.Query.encode(%{selected_photos: selected_photo_ids})
 
     uri =
-      case query do
-        "" -> uri
-        _ -> URI.append_query(uri, query)
-      end
+      if(!Enum.empty?(selected_photo_ids), do: URI.append_query(uri, selected_query), else: uri)
 
     URI.to_string(uri)
   end
@@ -447,8 +428,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def gallery(assigns) do
     grouped_photos = Enum.group_by(assigns.photos, & &1.group)
     assigns = assign(assigns, :grouped_photos, grouped_photos)
-
-    Logger.debug("collapse groups: #{inspect(assigns.collapse_groups)}")
 
     assigns =
       case assigns.collapse_groups do
@@ -744,6 +723,27 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     """
   end
 
+  def refresh_socket(socket) do
+    folder = socket.assigns.folder
+    tags = socket.assigns.tags
+
+    {photo_id, selected_photo_ids} =
+      case socket.assigns.selected_photos do
+        [photo] -> {photo.id, []}
+        photos -> {nil, Enum.map(photos, & &1.id)}
+      end
+
+    expanded_state =
+      expand_state(socket, %{
+        folder: folder,
+        tags: tags,
+        photo_id: photo_id,
+        selected_photo_ids: selected_photo_ids
+      })
+
+    assign(socket, expanded_state)
+  end
+
   def handle_multi_photo_select(photo_id, socket) do
     selected_photos = socket.assigns.selected_photos
     # Remove the new photo from selected_photos if it is present, otherwise add it
@@ -782,13 +782,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   def handle_event("toggle_collapse_groups", _params, socket) do
-    {:noreply,
-     push_patch(socket,
-       to:
-         build_url(socket.assigns.folder, socket.assigns.selected_photos, socket.assigns.tags, %{
-           collapse_groups: !socket.assigns.collapse_groups
-         })
-     )}
+    {:noreply, assign(socket, :collapse_groups, !socket.assigns.collapse_groups)}
   end
 
   # Holding ctrl while clicking a photo will select multiple
@@ -808,6 +802,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         %{"photo_group" => photo_group, "ctrl_key_pressed" => ctrl_key_pressed},
         socket
       ) do
+    # TODO implement, then group field in multiselect mode form, then add collapsed to url
     group_photos = Enum.filter(socket.assigns.filtered_photos, &(&1.group == photo_group))
 
     group_already_selected =
@@ -837,6 +832,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
+     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -848,6 +844,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
+     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -862,6 +859,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
+     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -876,6 +874,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      socket
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
+     |> refresh_socket()
      |> refresh_selected_photos()}
   end
 
@@ -887,12 +886,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       {:ok, _photo} ->
         {:noreply,
          assign(socket, :all_folders, Gallery.list_folders_include_tags())
+         |> refresh_socket()
          |> refresh_selected_photos()
          |> put_flash(:info, "Photo updated successfully.")}
 
       {:error, failed_op, failed_value, _changeset} ->
         {:noreply,
-         socket
+         refresh_socket(socket)
          |> put_flash(
            :error,
            "Failed to update photo. Error #{failed_value} in step #{failed_op}."

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -136,13 +136,17 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     uri = if(folder, do: URI.append_path(uri, "/folders/#{folder}"), else: uri)
     uri = if(photo_id, do: URI.append_path(uri, "/photos/#{photo_id}"), else: uri)
 
-    tag_query = Plug.Conn.Query.encode(%{query_tags: tags})
-    uri = if(!Enum.empty?(tags), do: URI.append_query(uri, tag_query), else: uri)
-
-    selected_query = Plug.Conn.Query.encode(%{selected_photos: selected_photo_ids})
+    query =
+      %{}
+      |> Map.put(:query_tags, tags)
+      |> Map.put(:selected_photos, selected_photo_ids)
+      |> Plug.Conn.Query.encode()
 
     uri =
-      if(!Enum.empty?(selected_photo_ids), do: URI.append_query(uri, selected_query), else: uri)
+      case query do
+        "" -> uri
+        _ -> URI.append_query(uri, query)
+      end
 
     URI.to_string(uri)
   end
@@ -390,12 +394,11 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <.toggle_button
           selected={@collapse_groups}
           phx-click="toggle_collapse_groups"
+          class="flex items-center pl-3 pr-3"
         >
-          <span class="pl-2 pr-2">
-            <.icon name="hero-square-2-stack" />
-            <span class="sr-only md:not-sr-only">
-              Collapse groups
-            </span>
+          <.icon name="hero-square-3-stack-3d w-5 h-5" />
+          <span class="sr-only md:not-sr-only md:ml-1">
+            Collapse groups
           </span>
         </.toggle_button>
       </div>
@@ -403,12 +406,11 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <.toggle_button
           selected={@multiselect_active}
           phx-click="toggle_multiselect"
+          class="flex items-center pl-3 pr-3"
         >
-          <span class="pl-2 pr-2">
-            <.icon name="hero-squares-plus" />
-            <span class="sr-only md:not-sr-only">
-              Multiselect
-            </span>
+          <.icon name="hero-squares-plus" />
+          <span class="sr-only md:not-sr-only md:ml-1">
+            Multiselect
           </span>
         </.toggle_button>
       </div>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -458,7 +458,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
               class="h-full w-full relative
                 data-[selected]:outline outline-4 outline-offset-2 outline-blue-400
                 phx-click-loading:outline phx-click-loading:outline-blue-200"
-              data-selected={Enum.member?(@selected_photos, photo)}
+              data-selected={member_by_id?(@selected_photos, photo)}
               phx-click={if(represents_group, do: "select_gallery_group", else: "select_gallery_photo")}
               phx-value-photo_id={photo.id}
               phx-value-photo_group={photo.group}
@@ -647,6 +647,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     assigns = assign(assigns, :tags_to_remove, tags_to_remove)
     assigns = assign(assigns, :tags_in_limbo, tags_in_limbo)
 
+    assigns = assign(assigns, :groups, Enum.uniq(Enum.map(assigns.photos, & &1.group)))
+
     ~H"""
     <.list>
       <:item title="Selected photos">
@@ -721,6 +723,29 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <% end %>
         </div>
       </:item>
+      <:item title="Group">
+        <%= if Enum.count(@groups) > 1 do %>
+          <p>Photos belong to multiple groups:</p>
+          <ul class="list-disc list-inside mb-2">
+            <%= for group <- @groups do %>
+              <li>{if group != nil, do: group, else: "No group"}</li>
+            <% end %>
+          </ul>
+        <% end %>
+        <.form for={Component.to_form(%{"group" => ""})} phx-submit="set_group_bulk">
+          <div class="flex items-center space-x-4">
+            <input
+              type="text"
+              name="group"
+              id="bulk_group_input"
+              Placeholder="group"
+              class="block max-w-64 rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6"
+              value={if(Enum.count(@groups) == 1, do: Enum.at(@groups, 0), else: "")}
+            />
+            <.button type="submit">Submit</.button>
+          </div>
+        </.form>
+      </:item>
     </.list>
     """
   end
@@ -767,14 +792,25 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      )}
   end
 
-  def refresh_selected_photos(socket) do
-    selected_photo_ids = socket.assigns.selected_photos |> Enum.map(& &1.id)
-
+  def refresh_photos(socket) do
     selected_photos =
-      Enum.map(selected_photo_ids, &Gallery.get_photo!(&1))
+      socket.assigns.selected_photos
+      |> Enum.map(& &1.id)
+      |> Enum.map(&Gallery.get_photo!(&1))
       |> Repo.preload(:tags)
 
-    assign(socket, selected_photos: selected_photos)
+    filtered_photos =
+      case {socket.assigns.folder, socket.assigns.tags} do
+        {nil, []} -> Gallery.list_photos()
+        {nil, tags} -> Gallery.list_photos_by_all_tags(tags)
+        {folder, []} -> Gallery.list_photos_by_folder(folder)
+        {folder, tags} -> Gallery.list_photos_by_folder_and_tags(folder, tags)
+      end
+      |> Repo.preload(:tags)
+
+    socket
+    |> assign(selected_photos: selected_photos)
+    |> assign(filtered_photos: filtered_photos)
   end
 
   ## Event Handlers
@@ -808,7 +844,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     group_photos = Enum.filter(socket.assigns.filtered_photos, &(&1.group == photo_group))
 
     group_already_selected =
-      Enum.all?(group_photos, &Enum.member?(socket.assigns.selected_photos, &1))
+      Enum.all?(group_photos, &member_by_id?(socket.assigns.selected_photos, &1))
 
     # If not in multiselect mode, select all photos in the group
     # If in multiselect mode, and all photos in the group are already selected, remove them from the selection
@@ -835,7 +871,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
-     |> refresh_selected_photos()}
+     |> refresh_photos()}
   end
 
   def handle_event("remove_tag", %{"photo_id" => photo_id, "tag" => tag}, socket) do
@@ -847,7 +883,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
-     |> refresh_selected_photos()}
+     |> refresh_photos()}
   end
 
   def handle_event("add_tag_bulk", %{"tag" => tag}, socket) do
@@ -862,7 +898,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
-     |> refresh_selected_photos()}
+     |> refresh_photos()}
   end
 
   def handle_event("remove_tag_bulk", %{"tag" => tag}, socket) do
@@ -877,7 +913,17 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      |> assign(:all_tags, Gallery.list_tags())
      |> assign(:all_folders, Gallery.list_folders_include_tags())
      |> refresh_socket()
-     |> refresh_selected_photos()}
+     |> refresh_photos()}
+  end
+
+  def handle_event("set_group_bulk", %{"group" => group}, socket) do
+    selected_photos = socket.assigns.selected_photos
+
+    Enum.each(selected_photos, fn photo ->
+      {:ok, _} = Gallery.update_photo(photo, %{"group" => group})
+    end)
+
+    {:noreply, refresh_photos(socket)}
   end
 
   def handle_event("update_photo", %{"photo_id" => id, "photo" => photo_params}, socket) do
@@ -889,7 +935,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         {:noreply,
          assign(socket, :all_folders, Gallery.list_folders_include_tags())
          |> refresh_socket()
-         |> refresh_selected_photos()
+         |> refresh_photos()
          |> put_flash(:info, "Photo updated successfully.")}
 
       {:error, failed_op, failed_value, _changeset} ->
@@ -912,5 +958,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      |> assign(:all_tags, Gallery.list_tags())
      |> push_patch(to: build_url(socket.assigns.folder, nil, socket.assigns.tags))
      |> put_flash(:info, "Photo deleted successfully.")}
+  end
+
+  ## Utility functions
+  def member_by_id?(enumerable, %{id: id}) do
+    Enum.any?(enumerable, fn
+      %{id: ^id} -> true
+      _ -> false
+    end)
   end
 end

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -27,6 +27,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <.gallery_header
           item_count={Enum.count(@filtered_photos)}
           multiselect_active={@multiselect_active}
+          collapse_groups={@collapse_groups}
         />
         <div>
           <.gallery
@@ -70,6 +71,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       |> assign(:all_folders, Gallery.list_folders_include_tags())
       |> assign(:all_tags, Gallery.list_tags())
       |> assign(:multiselect_active, false)
+      |> assign(:collapse_groups, false)
       #  |> assign(%{
       #    folder: nil,
       #    tags: [],
@@ -377,30 +379,35 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
   attr(:item_count, :integer, required: true)
   attr(:multiselect_active, :boolean, required: true)
+  attr(:collapse_groups, :boolean, required: true)
 
   def gallery_header(assigns) do
-    button_colours =
-      case assigns.multiselect_active do
-        false ->
-          "border border-blue-600 text-blue-600 bg-white hover:bg-blue-100 hover:text-blue-800"
-
-        true ->
-          "bg-blue-600 text-white hover:bg-blue-700"
-      end
-
-    assigns = assign(assigns, :button_colours, button_colours)
-
     ~H"""
     <div class="flex items-center sticky top-0 bg-white">
       <div class="flex-1" />
       <div class="flex-none pl-3 pr-3">
+        <.toggle_button
+          selected={@collapse_groups}
+          phx-click="toggle_collapse_groups"
+        >
+          <span class="pl-2 pr-2">
+            <.icon name="hero-square-2-stack" />
+            <span class="sr-only md:not-sr-only">
+              Collapse groups
+            </span>
+          </span>
+        </.toggle_button>
+      </div>
+      <div class="flex-none pr-3">
         <.toggle_button
           selected={@multiselect_active}
           phx-click="toggle_multiselect"
         >
           <span class="pl-2 pr-2">
             <.icon name="hero-squares-plus" />
-            Multiselect
+            <span class="sr-only md:not-sr-only">
+              Multiselect
+            </span>
           </span>
         </.toggle_button>
       </div>
@@ -745,6 +752,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
   def handle_event("toggle_multiselect", _params, socket) do
     {:noreply, assign(socket, :multiselect_active, !socket.assigns.multiselect_active)}
+  end
+
+  def handle_event("toggle_collapse_groups", _params, socket) do
+    {:noreply, assign(socket, :collapse_groups, !socket.assigns.collapse_groups)}
   end
 
   # Holding ctrl while clicking a photo will select multiple

--- a/app/priv/repo/migrations/20250327175518_add_group_field_to_photos.exs
+++ b/app/priv/repo/migrations/20250327175518_add_group_field_to_photos.exs
@@ -1,0 +1,9 @@
+defmodule PhotoTagger.Repo.Migrations.AddGroupFieldToPhotos do
+  use Ecto.Migration
+
+  def change do
+    alter table(:photos) do
+      add :group, :string
+    end
+  end
+end


### PR DESCRIPTION
Resolves #4, #5, #22

Adds a group field to photos. Can be set at upload time, in edit form, and in multiselect. A new button in gallery header collapses groups so that only the first one appears.