### PR TITLE
UI tweaks from feedback

### DIFF
--- a/app/lib/photo_tagger_web/components/core_components.ex
+++ b/app/lib/photo_tagger_web/components/core_components.ex
@@ -270,6 +270,34 @@ defmodule PhotoTaggerWeb.CoreComponents do
     """
   end
 
+  attr :selected, :boolean, required: true
+  attr :href, :string, required: true
+  attr :nav_type, :atom, values: [:patch, :navigate, :href], default: :patch
+  attr :class, :string, default: nil
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def toggle_link(assigns) do
+    assigns = assign(assigns, :nav, Map.put(%{}, assigns.nav_type, assigns.href))
+    ~H"""
+    <.link
+      class={
+        ClassHelper.tw([
+          "border rounded-full px-1 my-1 no-underline",
+          "border border-blue-600 text-blue-600 bg-white hover:bg-blue-100 hover:text-blue-800",
+          "aria-selected:bg-blue-600 aria-selected:text-white aria-selected:hover:bg-blue-700",
+          @class
+        ])
+      }
+      aria-selected={if(@selected, do: "true", else: "false")}
+      {@nav}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
   @doc """
   Renders an input with label and error messages.
 

--- a/app/lib/photo_tagger_web/components/core_components.ex
+++ b/app/lib/photo_tagger_web/components/core_components.ex
@@ -566,7 +566,7 @@ defmodule PhotoTaggerWeb.CoreComponents do
     ~H"""
     <div class="mt-0">
       <dl class="-my-4 divide-y divide-zinc-100">
-        <div :for={item <- @item} class="flex gap-4 py-4 text-sm leading-6 sm:gap-8">
+        <div :for={item <- @item} class={ClassHelper.tw(["flex gap-4 py-4 text-sm leading-6 sm:gap-8", Map.get(item, :class, "")])}>
           <dt class="w-1/4 flex-none text-zinc-500">{item.title}</dt>
           <dd class="text-zinc-700">{render_slot(item)}</dd>
         </div>

--- a/app/lib/photo_tagger_web/components/core_components.ex
+++ b/app/lib/photo_tagger_web/components/core_components.ex
@@ -595,7 +595,7 @@ defmodule PhotoTaggerWeb.CoreComponents do
     <div class="mt-0">
       <dl class="-my-4 divide-y divide-zinc-100">
         <div :for={item <- @item} class={ClassHelper.tw(["flex gap-4 py-4 text-sm leading-6 sm:gap-8", Map.get(item, :class, "")])}>
-          <dt class="w-1/4 flex-none text-zinc-500">{item.title}</dt>
+          <dt class="hidden md:inline w-1/4 flex-none text-zinc-500">{item.title}</dt>
           <dd class="text-zinc-700">{render_slot(item)}</dd>
         </div>
       </dl>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -9,8 +9,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   alias PhotoTaggerWeb.HtmlHelpers
   import PhotoTaggerWeb.Components.Accordion
 
-  # require Logger
-
   def render(assigns) do
     ~H"""
     <div class="grid grid-cols-7 gap-4 h-full">
@@ -296,10 +294,16 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:tags, :list, default: [])
 
   def folder_nav_item(assigns) do
-    assigns = assign(assigns, :is_current_folder, assigns.current_folder == assigns.nav_folder)
+    recommended_tag_names = Enum.map(assigns.recommended_tags, & &1.name)
+
+    {recommended_nav_tags, other_nav_tags} =
+      Enum.split_with(assigns.nav_tags, &(&1 in recommended_tag_names))
 
     assigns =
-      assign(assigns, :recommended_tag_names, Enum.map(assigns.recommended_tags, & &1.name))
+      assigns
+      |> assign(:is_current_folder, assigns.current_folder == assigns.nav_folder)
+      |> assign(:recommended_nav_tags, recommended_nav_tags)
+      |> assign(:other_nav_tags, other_nav_tags)
 
     ~H"""
     <li>
@@ -310,44 +314,46 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           </p>
         </:trigger>
         <:panel default_expanded={@is_current_folder}>
-          <ul class="list-none pl-2">
-            <li>
-              <.link
-                class="data-[selected]:font-bold"
-                data-selected={Enum.empty?(@tags) && @is_current_folder}
-                patch={build_url(@nav_folder, [], [])}
-              >
-                All photos
-              </.link>
-            </li>
-            <%= for tag <- Enum.sort_by(@nav_tags, fn tag ->
-                cond do
-                  tag in @tags -> 0 # show currently selected tags first
-                  tag in @recommended_tag_names -> 1 # then recommended tags
-                  true -> 2 # then all other tags
-                end
-              end) do %>
-              <li>
-                <%= if @is_current_folder and tag in @recommended_tag_names do %>
-                  <.toggle_tag_button folder={@nav_folder} tags={@tags} toggled_tag={tag} class="">
-                    {tag}
-                  </.toggle_tag_button>
-                <% else %>
-                  <%!-- <.toggle_link selected={false}
-                    class="text-gray-500 border-gray-500"
-                    href={build_url(@nav_folder, [], [tag])} >
-                    {tag}
-                  </.toggle_link> --%>
-
-                  <.link
-                    patch={build_url(@nav_folder, [], [tag])}
-                  >
-                    {tag}
-                  </.link>
+          <div class="list-none pl-2">
+            <.link
+              class="data-[selected]:font-bold"
+              data-selected={Enum.empty?(@tags) && @is_current_folder}
+              patch={build_url(@nav_folder, [], [])}
+            >
+              All photos
+            </.link>
+            <div class="divide-y divide-zinc-300 my-2">
+              <ul class="flex flex-wrap my-2">
+                <%= for tag <- Enum.sort_by(@recommended_nav_tags, fn tag ->
+                    cond do
+                      tag in @tags -> 0 # show currently selected tags first
+                      # tag in @recommended_tag_names -> 1 # then recommended tags
+                      true -> 2 # then other tags
+                    end
+                  end) do %>
+                  <li class="mr-2 flex items-center">
+                      <.toggle_tag_button folder={@nav_folder} tags={@tags} toggled_tag={tag}>
+                        {tag}
+                      </.toggle_tag_button>
+                  </li>
                 <% end %>
-              </li>
-            <% end %>
-          </ul>
+              </ul>
+              <ul class="flex flex-wrap py-2">
+                <%= for tag <- @other_nav_tags do %>
+                  <li>
+                    <%!-- <.toggle_link selected={false}
+                      class="text-gray-500 border-gray-500"
+                      href={build_url(@nav_folder, [], [tag])} >
+                      {tag}
+                    </.toggle_link> --%>
+                    <.link class="text-zinc-500 mr-2 my-1" patch={build_url(@nav_folder, [], [tag])} >
+                      {tag}
+                    </.link>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
         </:panel>
       </.accordion>
     </li>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -270,16 +270,12 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       assign(assigns, :href, build_url(assigns.folder, assigns.selected_photos, tags_list))
 
     ~H"""
-    <.link
-      class={"rounded-full px-1 no-underline " <>
-        "bg-green-500 text-white hover:text-white " <> # styling if not in current filters
-        "data-[selected]:font-bold data-[selected]:bg-red-400 data-[selected]:text-black data-[selected]:hover:text-black" # styling if in current filters
-      }
-      data-selected={@toggled_tag in @tags}
-      patch={@href}
+    <.toggle_link
+      selected={@toggled_tag in @tags}
+      href={@href}
     >
       {render_slot(@inner_block)}
-    </.link>
+    </.toggle_link>
     """
   end
 
@@ -508,23 +504,22 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       <:item title="Tags">
         <ul class="flex flex-wrap">
           <%= for tag <- @photo.tags do %>
-            <li class="mr-2">
+            <li class="mr-2 flex items-center">
               <.toggle_tag_button
                 folder={@folder}
                 selected_photos={[@photo]}
                 tags={@tags}
                 toggled_tag={tag.name}
               >
-                {if(tag.name in @tags, do: "- ", else: "+ ") <> tag.name}
+                {tag.name}
               </.toggle_tag_button>
               <.form
-                class="inline"
                 for={Component.to_form(%{"tag" => tag.name, "photo_id" => @photo.id})}
                 phx-submit="remove_tag"
               >
                 <input class="hidden" type="text" name="photo_id" value={@photo.id} />
                 <input class="hidden" type="text" name="tag" value={tag.name} />
-                <button type="submit">
+                <button type="submit" class="flex items-center">
                   <.icon name="hero-trash-micro" class="text-red-700 hover:text-red-900" />
                 </button>
               </.form>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -530,9 +530,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             </li>
           <% end %>
         </ul>
-      </:item>
-      <:item title="Add tags">
-        <div>
+        <div class="mt-2">
           <.form for={Component.to_form(%{"tag" => "", "photo_id" => @photo.id})} phx-submit="add_tag">
             <input class="hidden" type="text" name="photo_id" value={@photo.id} />
             <div class="flex items-center space-x-4">

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -309,20 +309,22 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     <li>
       <.accordion id={folder_accordion_id(@nav_folder)}>
         <:trigger>
-          <p class="text-left data-[selected]:font-bold" data-selected={@is_current_folder}>
+          <%!-- <p class="text-left data-[selected]:font-bold" data-selected={@is_current_folder}>
             {if(@nav_folder, do: @nav_folder, else: "All folders")}
+          </p> --%>
+          <p class="text-left">
+            <.link
+                class="data-[selected]:font-bold"
+                data-selected={Enum.empty?(@tags) && @is_current_folder}
+                patch={build_url(@nav_folder, [], [])}
+              >
+              {if(@nav_folder, do: @nav_folder, else: "All folders")}
+            </.link>
           </p>
         </:trigger>
         <:panel default_expanded={@is_current_folder}>
-          <div class="list-none pl-2">
-            <.link
-              class="data-[selected]:font-bold"
-              data-selected={Enum.empty?(@tags) && @is_current_folder}
-              patch={build_url(@nav_folder, [], [])}
-            >
-              All photos
-            </.link>
-            <div class="divide-y divide-zinc-300 my-2">
+          <div class="divide-y divide-zinc-300 my-2 pl-2 list-none">
+            <%= if not Enum.empty?(@recommended_nav_tags) do %>
               <ul class="flex flex-wrap my-2">
                 <%= for tag <- Enum.sort_by(@recommended_nav_tags, fn tag ->
                     cond do
@@ -338,6 +340,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                   </li>
                 <% end %>
               </ul>
+            <% end %>
+            <%= if not Enum.empty?(@other_nav_tags) do %>
               <ul class="flex flex-wrap py-2">
                 <%= for tag <- @other_nav_tags do %>
                   <li>
@@ -352,7 +356,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                   </li>
                 <% end %>
               </ul>
-            </div>
+            <% end %>
           </div>
         </:panel>
       </.accordion>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -490,9 +490,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def photo(assigns) do
     ~H"""
     <.list>
-      <:item title="Image">
+      <%!-- On medium screens and above, sticky the image section to the top --%>
+      <:item title="Image" class="max-h-[40vh] md:sticky md:top-0 md:bg-white md:border-b md:border-zinc-100 md:mb-4 md:z-10">
         <.link href={ImageUploader.url({@photo.image, @photo}, :original)} target="_blank">
-          <img img={@photo.name} src={ImageUploader.url({@photo.image, @photo}, :small)} />
+          <img class="object-contain h-full" img={@photo.name} src={ImageUploader.url({@photo.image, @photo}, :small)} />
         </.link>
       </:item>
       <:item title="Folder">

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -251,6 +251,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:selected_photos, :list, default: [])
   attr(:tags, :list, default: [])
   attr(:toggled_tag, :string, required: true)
+  attr(:class, :string, default: "")
   slot(:inner_block)
 
   def toggle_tag_button(assigns) do
@@ -273,6 +274,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     <.toggle_link
       selected={@toggled_tag in @tags}
       href={@href}
+      class={@class}
     >
       {render_slot(@inner_block)}
     </.toggle_link>
@@ -308,7 +310,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           </p>
         </:trigger>
         <:panel default_expanded={@is_current_folder}>
-          <ul class="list-disc list-inside">
+          <ul class="list-none pl-2">
             <li>
               <.link
                 class="data-[selected]:font-bold"
@@ -326,17 +328,22 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                 end
               end) do %>
               <li>
-                <.link
-                  class="data-[selected]:font-bold"
-                  data-selected={@is_current_folder && tag in @tags}
-                  patch={build_url(@nav_folder, [], [tag])}
-                >
-                  {tag}
-                </.link>
                 <%= if @is_current_folder and tag in @recommended_tag_names do %>
-                  <.toggle_tag_button folder={@nav_folder} tags={@tags} toggled_tag={tag}>
-                    {if(tag in @tags, do: "-", else: "+")}
+                  <.toggle_tag_button folder={@nav_folder} tags={@tags} toggled_tag={tag} class="">
+                    {tag}
                   </.toggle_tag_button>
+                <% else %>
+                  <%!-- <.toggle_link selected={false}
+                    class="text-gray-500 border-gray-500"
+                    href={build_url(@nav_folder, [], [tag])} >
+                    {tag}
+                  </.toggle_link> --%>
+
+                  <.link
+                    patch={build_url(@nav_folder, [], [tag])}
+                  >
+                    {tag}
+                  </.link>
                 <% end %>
               </li>
             <% end %>


### PR DESCRIPTION
Resolves #56 #52 #58 #55 #54 #61

Combines tags and add tag sections in photo pane
Move folder link to accordion trigger
Photo image section is sticky on large screens, but limited in height
Restyle toggle tag links to match other toggle buttons, remove + and minus
Horizontally stack tags in nav, instead of vertical list
In mobile view, hide photo section labels