### PR TITLE
Improve layout on small screens

### DIFF
--- a/app/assets/tailwind.config.js
+++ b/app/assets/tailwind.config.js
@@ -18,6 +18,12 @@ module.exports = {
       }
     },
   },
+  safelist: [
+    {
+      pattern: /grid-cols-[123456789]/,
+      variants: ['sm', 'md', 'lg', 'xl', '2xl'],
+    },
+  ],
   plugins: [
     require("@tailwindcss/forms"),
     // Allows prefixing tailwind classes with LiveView classes to add rules

--- a/app/lib/photo_tagger_web/components/accordion.ex
+++ b/app/lib/photo_tagger_web/components/accordion.ex
@@ -48,7 +48,7 @@ defmodule PhotoTaggerWeb.Components.Accordion do
           >
             {render_slot(trigger)}
             <.icon
-              class="accordion-trigger-icon h-5 w-5 absolute right-4 transition-all ease-in-out duration-100 top-1/2 -translate-y-1/2"
+              class="hero-chevron-down-micro md:hero-chevron-down-mini lg:hero-chevron-down accordion-trigger-icon h-3 w-3 md:h-4 md:w-4 lg:h-5 lg:w-5 absolute right-4 transition-all ease-in-out duration-100 top-1/2 -translate-y-1/2"
               name={trigger[:icon_name] || "hero-chevron-down"}
             />
           </button>

--- a/app/lib/photo_tagger_web/components/core_components.ex
+++ b/app/lib/photo_tagger_web/components/core_components.ex
@@ -595,7 +595,7 @@ defmodule PhotoTaggerWeb.CoreComponents do
     <div class="mt-0">
       <dl class="-my-4 divide-y divide-zinc-100">
         <div :for={item <- @item} class={ClassHelper.tw(["flex gap-4 py-4 text-sm leading-6 sm:gap-8", Map.get(item, :class, "")])}>
-          <dt class="hidden md:inline w-1/4 flex-none text-zinc-500">{item.title}</dt>
+          <dt class="hidden lg:inline w-1/4 flex-none text-zinc-500">{item.title}</dt>
           <dd class="text-zinc-700">{render_slot(item)}</dd>
         </div>
       </dl>

--- a/app/lib/photo_tagger_web/components/layouts/app.html.heex
+++ b/app/lib/photo_tagger_web/components/layouts/app.html.heex
@@ -1,7 +1,9 @@
 <div class="h-screen flex flex-col">
   <div class="p-2 ">
     <.header>
-      Photo Tagger
+      <span class="hidden md:inline">
+        Photo Tagger
+      </span>      
       <:actions>
         <.link class="px-4" href={~p"/edit-tags"}>
           Edit Tags
@@ -10,7 +12,7 @@
           Edit Folders
         </.link>
         <.link href={~p"/photos/new"}>
-          <.button>Upload Photos</.button>
+          <.button class="py-2 md:py-1 lg:py-2">Upload Photos</.button>
         </.link>
       </:actions>
     </.header>
@@ -20,7 +22,7 @@
     <.flash_group flash={@flash} />
   </div>
 
-  <main class="overflow-y-auto overscroll-none">
+  <main class="pl-4 sm:pl-6 lg:pl-8 overflow-y-auto overscroll-none">
     {@inner_content}
   </main>
 </div>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -9,6 +9,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   alias PhotoTaggerWeb.HtmlHelpers
   import PhotoTaggerWeb.Components.Accordion
 
+  require Logger
+
   def render(assigns) do
     ~H"""
     <div class="grid grid-cols-7 gap-4 h-full">
@@ -484,7 +486,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       size = clamp(base_size - zoom_level, 1, 9)
       "grid-cols-#{size}"
     end
-
     assigns =
       assigns
       |> assign(:grid_size, get_grid_size.(assigns.zoom_level, 1))
@@ -1017,11 +1018,11 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   def handle_event("zoom_in", _params, socket) do
-    {:noreply, assign(socket, :zoom_level, clamp(socket.assigns.zoom_level + 1, 1, 9))}
+    {:noreply, assign(socket, :zoom_level, clamp(socket.assigns.zoom_level + 1, -9, 9))}
   end
 
   def handle_event("zoom_out", _params, socket) do
-    {:noreply, assign(socket, :zoom_level, clamp(socket.assigns.zoom_level - 1, 1, 9))}
+    {:noreply, assign(socket, :zoom_level, clamp(socket.assigns.zoom_level - 1, -9, 9))}
   end
 
   ## Utility functions

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -90,21 +90,20 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     photo_id = Map.get(params, "photo_id")
     selected_photo_ids = Map.get(params, "selected_photos", [])
 
-    zoom_level =
-      Map.get(params, "zoom", "0")
-      |> Integer.parse()
-      |> case do
-        {zoom_level, _} -> zoom_level
-        :error -> 0
-      end
+    # zoom_level =
+    #   Map.get(params, "zoom", "0")
+    #   |> Integer.parse()
+    #   |> case do
+    #     {zoom_level, _} -> zoom_level
+    #     :error -> 0
+    #   end
 
     expanded_state =
       expand_state(socket, %{
         folder: folder,
         tags: tags,
         photo_id: photo_id,
-        selected_photo_ids: selected_photo_ids,
-        zoom_level: zoom_level
+        selected_photo_ids: selected_photo_ids
       })
 
     # Reset scroll position of a section if the relevent params change
@@ -168,8 +167,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           # This id comes from the url path
           photo_id: photo_id,
           # These come from url query params
-          selected_photo_ids: selected_photo_ids,
-          zoom_level: zoom_level
+          selected_photo_ids: selected_photo_ids
         }
       ) do
     prev_folder = Map.get(socket.assigns, :folder)
@@ -253,8 +251,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       filtered_photos: filtered_photos,
       selected_photos: selected_photos,
       recommended_tags: recommended_tags,
-      update_photo_form: update_photo_form,
-      zoom_level: zoom_level
+      update_photo_form: update_photo_form
     }
   end
 
@@ -415,7 +412,17 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def gallery_header(assigns) do
     ~H"""
     <div class="flex flex-row-reverse flex-wrap items-center sticky top-0 bg-white z-50">
-      <div class="flex-none mr-3 lg-ml-3">
+      <div class="flex-none pr-3">
+        <.button class="p-1 flex items-center" phx-click="zoom_out">
+          <.icon name="hero-magnifying-glass-minus" class="hero-magnifying-glass-minus-mini lg:hero-magnifying-glass-minus w-4 h-4 lg:w-5 lg:h-5" />
+        </.button>
+      </div>
+      <div class="flex-none pr-1">
+        <.button class="p-1 flex items-center" phx-click="zoom_in">
+          <.icon name="hero-magnifying-glass-plus" class="hero-magnifying-glass-plus-mini lg:hero-magnifying-glass-plus w-4 h-4 lg:w-5 lg:h-5" />
+        </.button>
+      </div>
+      <div class="flex-none mr-3 lg:ml-3">
         <p class="font-bold">{"#{@item_count}"}<span class="hidden md:inline">{" items"}</span></p>
       </div>
       <div class="flex-none pr-3">
@@ -473,17 +480,19 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           )
       end
 
-    clamp = fn x, min, max -> min(max(x, min), max) end
     get_grid_size = fn zoom_level, base_size ->
-      size = clamp.(base_size - zoom_level, 1, 9)
+      size = clamp(base_size - zoom_level, 1, 9)
       "grid-cols-#{size}"
     end
-    assigns = assigns
+
+    assigns =
+      assigns
       |> assign(:grid_size, get_grid_size.(assigns.zoom_level, 1))
       |> assign(:md_grid_size, get_grid_size.(assigns.zoom_level, 2))
       |> assign(:lg_grid_size, get_grid_size.(assigns.zoom_level, 4))
       |> assign(:xl_grid_size, get_grid_size.(assigns.zoom_level, 4))
       |> assign(:_2xl_grid_size, get_grid_size.(assigns.zoom_level, 6))
+
     ~H"""
     <div class="p-2 lg:p-6 ">
       <ul class={"grid gap-2 lg:gap-4
@@ -1007,6 +1016,14 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
      |> put_flash(:info, "Photos deleted successfully.")}
   end
 
+  def handle_event("zoom_in", _params, socket) do
+    {:noreply, assign(socket, :zoom_level, clamp(socket.assigns.zoom_level + 1, 1, 9))}
+  end
+
+  def handle_event("zoom_out", _params, socket) do
+    {:noreply, assign(socket, :zoom_level, clamp(socket.assigns.zoom_level - 1, 1, 9))}
+  end
+
   ## Utility functions
   def member_by_id?(enumerable, %{id: id}) do
     Enum.any?(enumerable, fn
@@ -1014,4 +1031,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       _ -> false
     end)
   end
+
+  def clamp(x, min, max), do: min(max(x, min), max)
 end

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -460,15 +460,16 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       end
 
     ~H"""
-    <div>
-      <ul class="flex flex-wrap gap-4 p-6">
+    <div class="p-2 lg:p-6 ">
+      <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl-grid-cols-6 gap-2 lg:gap-4">
         <%= for photo <- @photos do %>
           <% represents_group = @collapse_groups and photo.group != nil and Enum.count(@grouped_photos[photo.group]) > 1 %>
-          <li class="w-40 h-40">
+          <li class="aspect-square">
             <button
               id={"gallery-photo-button-#{photo.id}"}
-              class="h-full w-full relative
-                data-[selected]:outline outline-4 outline-offset-2 outline-blue-400
+              class="h-full w-full relative block
+                data-[selected]:outline
+                outline-4 outline-offset-2 outline-blue-400
                 phx-click-loading:outline phx-click-loading:outline-blue-200"
               data-selected={member_by_id?(@selected_photos, photo)}
               phx-click={if(represents_group, do: "select_gallery_group", else: "select_gallery_photo")}
@@ -477,13 +478,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             >
               <%!-- use object-cover for cropped squares, and object-contain for shrinked full images --%>
               <img
-                class="w-40 h-40 object-cover"
+                class="w-full h-full object-cover"
                 alt={photo.name}
                 src={ImageUploader.url({photo.image, photo}, :small)}
               />
               <%= if represents_group do %>
-                <div class="w-40 h-40 -z-10 absolute left-1 bottom-1 bg-gray-500" />
-                <div class="w-40 h-40 -z-20 absolute left-2 bottom-2 bg-gray-400" />
+                <div class="w-full h-full -z-10 absolute left-1 bottom-1 bg-gray-500" />
+                <div class="w-full h-full -z-20 absolute left-2 bottom-2 bg-gray-400" />
               <% end %>
             </button>
           </li>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -34,6 +34,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             tags={@tags}
             selected_photos={@selected_photos}
             collapse_groups={@collapse_groups}
+            zoom_level={@zoom_level}
           />
         </div>
       </div>
@@ -71,6 +72,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       |> assign(:all_tags, Gallery.list_tags())
       |> assign(:multiselect_active, false)
       |> assign(:collapse_groups, false)
+      |> assign(:zoom_level, 0)
       #  |> assign(%{
       #    folder: nil,
       #    tags: [],
@@ -88,12 +90,21 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     photo_id = Map.get(params, "photo_id")
     selected_photo_ids = Map.get(params, "selected_photos", [])
 
+    zoom_level =
+      Map.get(params, "zoom", "0")
+      |> Integer.parse()
+      |> case do
+        {zoom_level, _} -> zoom_level
+        :error -> 0
+      end
+
     expanded_state =
       expand_state(socket, %{
         folder: folder,
         tags: tags,
         photo_id: photo_id,
-        selected_photo_ids: selected_photo_ids
+        selected_photo_ids: selected_photo_ids,
+        zoom_level: zoom_level
       })
 
     # Reset scroll position of a section if the relevent params change
@@ -157,7 +168,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           # This id comes from the url path
           photo_id: photo_id,
           # These come from url query params
-          selected_photo_ids: selected_photo_ids
+          selected_photo_ids: selected_photo_ids,
+          zoom_level: zoom_level
         }
       ) do
     prev_folder = Map.get(socket.assigns, :folder)
@@ -241,7 +253,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       filtered_photos: filtered_photos,
       selected_photos: selected_photos,
       recommended_tags: recommended_tags,
-      update_photo_form: update_photo_form
+      update_photo_form: update_photo_form,
+      zoom_level: zoom_level
     }
   end
 
@@ -438,6 +451,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:tags, :list, default: [])
   attr(:selected_photos, :list, default: [])
   attr(:collapse_groups, :boolean, default: false)
+  attr(:zoom_level, :integer, default: 0)
 
   def gallery(assigns) do
     grouped_photos = Enum.group_by(assigns.photos, & &1.group)
@@ -459,9 +473,25 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           )
       end
 
+    clamp = fn x, min, max -> min(max(x, min), max) end
+    get_grid_size = fn zoom_level, base_size ->
+      size = clamp.(base_size - zoom_level, 1, 9)
+      "grid-cols-#{size}"
+    end
+    assigns = assigns
+      |> assign(:grid_size, get_grid_size.(assigns.zoom_level, 1))
+      |> assign(:md_grid_size, get_grid_size.(assigns.zoom_level, 2))
+      |> assign(:lg_grid_size, get_grid_size.(assigns.zoom_level, 4))
+      |> assign(:xl_grid_size, get_grid_size.(assigns.zoom_level, 4))
+      |> assign(:_2xl_grid_size, get_grid_size.(assigns.zoom_level, 6))
     ~H"""
     <div class="p-2 lg:p-6 ">
-      <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl-grid-cols-6 gap-2 lg:gap-4">
+      <ul class={"grid gap-2 lg:gap-4
+      #{@grid_size}
+      md:#{@md_grid_size}
+      lg:#{@lg_grid_size}
+      xl:#{@xl_grid_size}
+      2xl:#{@_2xl_grid_size}"}>
         <%= for photo <- @photos do %>
           <% represents_group = @collapse_groups and photo.group != nil and Enum.count(@grouped_photos[photo.group]) > 1 %>
           <li class="aspect-square">

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -12,7 +12,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def render(assigns) do
     ~H"""
     <div class="grid grid-cols-7 gap-4 h-full">
-      <div id="folders-section" class="col-span-1 overflow-y-auto pl-4 sm:pl-6 lg:pl-8 ">
+      <div id="folders-section" class="col-span-2 lg:col-span-1 overflow-y-auto">
         <.folders
           all_folders={@all_folders}
           all_tags={@all_tags}
@@ -21,7 +21,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           recommended_tags={@recommended_tags}
         />
       </div>
-      <div id="gallery-section" class="col-span-4 overflow-y-auto">
+      <div id="gallery-section" class="col-span-3 lg:col-span-4 overflow-y-auto">
         <.gallery_header
           item_count={Enum.count(@filtered_photos)}
           multiselect_active={@multiselect_active}
@@ -373,8 +373,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   def folders(assigns) do
     ~H"""
     <div>
-      <h2>Folders</h2>
-      <ul class="space-y-2 mt-2">
+      <h2 class="hidden lg:block">Folders</h2>
+      <ul class="space-y-2 mt-2 text-sm md:text-base">
         <.folder_nav_item
           current_folder={@folder}
           nav_tags={Enum.map(@all_tags, & &1.name)}

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -429,25 +429,23 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       </div>
       <div class="flex-none pr-3">
         <.toggle_button
-          selected={@multiselect_active}
-          phx-click="toggle_multiselect"
-          class="flex items-center pl-3 pr-3"
-        >
-          <.icon name="hero-squares-plus" class="hero-squares-plus-mini lg:hero-squares-plus my-1 lg:my-0 w-4 h-4 lg:w-5 lg:h-5" />
-          <span class="sr-only lg:not-sr-only lg:ml-1">
-            Multiselect
-          </span>
-        </.toggle_button>
-      </div>
-      <div class="flex-none pl-3 pr-3">
-        <.toggle_button
           selected={@collapse_groups}
           phx-click="toggle_collapse_groups"
-          class="flex items-center pl-3 pr-3"
+          class="flex items-center pl-3 pr-3 inline mr-1"
         >
           <.icon name="hero-square-3-stack-3d" class="hero-square-3-stack-3d-mini lg:hero-square-3-stack-3d my-1 lg:my-0 w-4 h-4 lg:w-5 lg:h-5" />
           <span class="sr-only lg:not-sr-only lg:ml-1">
             Collapse groups
+          </span>
+        </.toggle_button>
+        <.toggle_button
+          selected={@multiselect_active}
+          phx-click="toggle_multiselect"
+          class="flex items-center pl-3 pr-3 inline"
+        >
+          <.icon name="hero-squares-plus" class="hero-squares-plus-mini lg:hero-squares-plus my-1 lg:my-0 w-4 h-4 lg:w-5 lg:h-5" />
+          <span class="sr-only lg:not-sr-only lg:ml-1">
+            Multiselect
           </span>
         </.toggle_button>
       </div>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -410,7 +410,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           class="flex items-center pl-3 pr-3"
         >
           <.icon name="hero-square-3-stack-3d w-5 h-5" />
-          <span class="sr-only md:not-sr-only md:ml-1">
+          <span class="sr-only lg:not-sr-only lg:ml-1">
             Collapse groups
           </span>
         </.toggle_button>
@@ -422,7 +422,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           class="flex items-center pl-3 pr-3"
         >
           <.icon name="hero-squares-plus" />
-          <span class="sr-only md:not-sr-only md:ml-1">
+          <span class="sr-only lg:not-sr-only lg:ml-1">
             Multiselect
           </span>
         </.toggle_button>
@@ -504,7 +504,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     ~H"""
     <.list>
       <%!-- On medium screens and above, sticky the image section to the top --%>
-      <:item title="Image" class="max-h-[40vh] md:sticky md:top-0 md:bg-white md:border-b md:border-zinc-100 md:mb-4 md:z-10">
+      <:item title="Image" class="max-h-[40vh] lg:sticky lg:top-0 lg:bg-white lg:border-b lg:border-zinc-100 lg:mb-4 lg:z-10">
         <.link href={ImageUploader.url({@photo.image, @photo}, :original)} target="_blank">
           <img class="object-contain h-full" img={@photo.name} src={ImageUploader.url({@photo.image, @photo}, :small)} />
         </.link>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -401,19 +401,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
   def gallery_header(assigns) do
     ~H"""
-    <div class="flex items-center sticky top-0 bg-white z-50">
-      <div class="flex-1" />
-      <div class="flex-none pl-3 pr-3">
-        <.toggle_button
-          selected={@collapse_groups}
-          phx-click="toggle_collapse_groups"
-          class="flex items-center pl-3 pr-3"
-        >
-          <.icon name="hero-square-3-stack-3d w-5 h-5" />
-          <span class="sr-only lg:not-sr-only lg:ml-1">
-            Collapse groups
-          </span>
-        </.toggle_button>
+    <div class="flex flex-row-reverse flex-wrap items-center sticky top-0 bg-white z-50">
+      <div class="flex-none mr-3 lg-ml-3">
+        <p class="font-bold">{"#{@item_count}"}<span class="hidden md:inline">{" items"}</span></p>
       </div>
       <div class="flex-none pr-3">
         <.toggle_button
@@ -421,14 +411,23 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           phx-click="toggle_multiselect"
           class="flex items-center pl-3 pr-3"
         >
-          <.icon name="hero-squares-plus" />
+          <.icon name="hero-squares-plus" class="hero-squares-plus-mini lg:hero-squares-plus my-1 lg:my-0 w-4 h-4 lg:w-5 lg:h-5" />
           <span class="sr-only lg:not-sr-only lg:ml-1">
             Multiselect
           </span>
         </.toggle_button>
       </div>
-      <div class="flex-none pl-3 pr-3 mr-4">
-        <p class="font-bold">{"#{@item_count} items"}</p>
+      <div class="flex-none pl-3 pr-3">
+        <.toggle_button
+          selected={@collapse_groups}
+          phx-click="toggle_collapse_groups"
+          class="flex items-center pl-3 pr-3"
+        >
+          <.icon name="hero-square-3-stack-3d" class="hero-square-3-stack-3d-mini lg:hero-square-3-stack-3d my-1 lg:my-0 w-4 h-4 lg:w-5 lg:h-5" />
+          <span class="sr-only lg:not-sr-only lg:ml-1">
+            Collapse groups
+          </span>
+        </.toggle_button>
       </div>
     </div>
     """

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -586,7 +586,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <div class="mt-2">
           <.form for={Component.to_form(%{"tag" => "", "photo_id" => @photo.id})} phx-submit="add_tag">
             <input class="hidden" type="text" name="photo_id" value={@photo.id} />
-            <div class="flex items-center space-x-4">
+            <div class="flex flex-wrap gap-2">
               <%!-- TODO: convert this simple inline form to a component --%>
               <%!-- <.label for="add_any_tag">Add tag</.label> --%>
               <input
@@ -594,7 +594,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                 name="tag"
                 id="add_any_tag"
                 Placeholder="Add tag"
-                class="block max-w-64 rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6"
+                class="rounded-lg w-full max-w-40 text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6"
               />
               <.button type="submit">Submit</.button>
             </div>

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -337,7 +337,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <:panel default_expanded={@is_current_folder}>
           <div class="divide-y divide-zinc-300 my-2 pl-2 list-none">
             <%= if not Enum.empty?(@recommended_nav_tags) do %>
-              <ul class="flex flex-wrap my-2">
+              <ul class="md:flex md:flex-wrap my-2">
                 <%= for tag <- Enum.sort_by(@recommended_nav_tags, fn tag ->
                     cond do
                       tag in @tags -> 0 # show currently selected tags first
@@ -354,7 +354,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
               </ul>
             <% end %>
             <%= if not Enum.empty?(@other_nav_tags) do %>
-              <ul class="flex flex-wrap py-2">
+              <ul class="md:flex md:flex-wrap py-2">
                 <%= for tag <- @other_nav_tags do %>
                   <li>
                     <%!-- <.toggle_link selected={false}


### PR DESCRIPTION
Resolves #63 
Resolves #30 

Makes layout much more responsive to screen width, with focus on Laptop screen size, Pixel 7 portrait mode, and Pixel 7 Landscape mode. Changes include hiding some non-vital text and resizing icons.
Adds zoom buttons to gallery.
Gallery photos now resize to take up full gallery space.
