### PR TITLE
Feature/nav pane improvements

### DIFF
--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -19,6 +19,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <.live_component
             id="nav-panel"
             module={PhotoTaggerWeb.GalleryLive.NavPanel}
+            folder={@folder}
+            all_folders={@all_folders}
             nav_tags={@nav_tags}
             recommended_tags={@recommended_tags}
             current_tags={@tags}
@@ -31,7 +33,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       <div id="gallery-section" class="flex-grow basis-3/7 lg:basis-2/7 overflow-y-auto">
         <.gallery_header
           folder={@folder}
-          all_folders={@all_folders}
           tags={@tags}
           item_count={Enum.count(@filtered_photos)}
           multiselect_active={@multiselect_active}
@@ -333,7 +334,6 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   attr(:folder, :string, default: nil)
-  attr(:all_folders, :list, required: true)
   attr(:tags, :list, default: [])
   attr(:item_count, :integer, required: true)
   attr(:multiselect_active, :boolean, required: true)
@@ -346,27 +346,22 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
     ~H"""
     <div class="md:flex sticky top-0 bg-white z-50">
-      <div class="flex-grow pb-1">
+      <nav aria-label="Breadcrumb" class="flex-grow pb-1">
         <ul class="flex flex-wrap items-center">
-          <li>
-            <%!-- <.icon name="hero-folder" class="hidden md:inline"/> --%>
-            <span class="hidden md:inline">Folder:</span>
-            <form class="inline" phx-change="change_folder">
-              <select value={@folder} name="folder" id="folder-select"  class="ml-2 mr-2">
-                <option value="">All folders</option>
-                <%= for folder <- @all_folders do %>
-                  <option value={folder} selected={@folder == folder}>
-                    {folder}
-                  </option>
-                <% end %>
-              </select>
-            </form>
+          <li class="align-middle pr-2">
+            <.icon name="hero-folder" class=" w-4 h-4 lg:w-5 lg:h-5"/>
+            <.link
+              aria-current={if(length(@breadcrumb_tags) == 0, do: "page", else: "false")}
+              patch={Util.build_url(@folder, [], [], @is_admin)}
+            >
+              {@folder}
+            </.link>
           </li>
-          <%= for [tag | _] = tags <- @breadcrumb_tags do %>
+          <%= for {[tag | _] = tags, index} <- Enum.with_index(@breadcrumb_tags) do %>
             <li class="">
               <.icon name="hero-chevron-right" class="hero-chevron-right-mini lg:hero-chevron-right w-4 h-4 lg:w-5 lg:h-5"/>
               <.link
-                class=""
+                aria-current={if(index == length(@breadcrumb_tags) - 1, do: "page", else: "false")}
                 patch={Util.build_url(@folder, [], Enum.reverse(tags), @is_admin)}
               >
                 #{tag}
@@ -374,7 +369,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             </li>
           <% end %>
         </ul>
-      </div>
+      </nav>
       <div class="flex-none pb-1 lg:pb-2 flex flex-row-reverse flex-wrap items-center">
         <div class="flex-none pr-3">
           <.button class="p-1 flex items-center" phx-click="zoom_out">

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -16,7 +16,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     ~H"""
     <div class="h-full">
       <div class="flex flex-row gap-4 h-full">
-        <div id="tags-section" class="shrink basis-0 overflow-y-auto">
+        <div id="tags-section" class="shrink basis-2/7 lg:basis-1/7 overflow-y-auto">
           <.live_component
               id="nav-panel"
               module={PhotoTaggerWeb.GalleryLive.NavPanel}
@@ -31,7 +31,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
               <%!-- selected_photo_ids={@selected_photo_ids} --%>
               <%!-- folder={@folder} --%>
         </div>
-        <div id="gallery-section" class="flex-grow basis-3/7 lg:basis-2/7 overflow-y-auto">
+        <div id="gallery-section" class="flex-grow basis-3/7 lg:basis-4/7 overflow-y-auto">
           <.gallery_header
             folder={@folder}
             tags={@tags}

--- a/app/lib/photo_tagger_web/live/gallery_live/nav_panel.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/nav_panel.ex
@@ -1,5 +1,6 @@
 defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
   use PhotoTaggerWeb, :live_component
+  require Logger
 
   attr(:folder, :string, required: true)
   attr(:all_folders, :list, required: true)
@@ -42,9 +43,62 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
         </form>
         <h2 class="">Tags</h2>
         <nav class="my-2 pl-2 list-none">
-          <%= if not Enum.empty?(@recommended_nav_tags) do %>
+          <%= if not Enum.empty?(@current_tags) do %>
+            <ul class="my-2">
+              <%= for tag <- @current_tags do %>
+                <li class="mr-2">
+                  <.toggle_button
+                    selected={true}
+                    phx-click="toggle_tag"
+                    phx-value-tag={tag}
+                  >
+                    {tag}
+                  </.toggle_button>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+          <%= if not Enum.empty?(@recommended_nav_tags)
+            and (@max_recommended_tags < 0
+            or Enum.count(@recommended_nav_tags) <= @max_recommended_tags)
+          do %>
             <ul class="my-2">
               <%= for tag <- @recommended_nav_tags do %>
+                <li class="mr-2">
+                  <.toggle_button
+                    selected={tag in @current_tags}
+                    phx-click="toggle_tag"
+                    phx-value-tag={tag}
+                  >
+                    {tag}
+                  </.toggle_button>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+          <ul id="index-selecors" class="flex flex-wrap mb-2">
+            <%= for {index, tags} <- Enum.sort(@indexed_tags) do %>
+              <li>
+                <%= if Enum.empty?(tags) do %>
+                  {index}
+                <% else %>
+                  <button
+                    phx-click="select_index"
+                    phx-value-index={index}
+                    phx-target={@myself}
+                    class="underline text-blue-600 hover:text-blue-800 mr-2 aria-selected:font-bold"
+                    aria-selected={if(@selected_index == index, do: "true", else: "false")}
+                  >
+                    {index}
+                  </button>
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+          <%= if @selected_index != nil do %>
+            <%= for tag <- Map.get(@indexed_tags, @selected_index) do %>
+              <ul>
+              <%= if tag in @current_tags or tag in @recommended_nav_tags do %>
                 <li class="mr-2 content-visible-auto">
                   <.toggle_button
                     selected={tag in @current_tags}
@@ -53,43 +107,20 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
                   >
                     {tag}
                   </.toggle_button>
-
-                  <%!-- <.live_component
-                    module={PhotoTaggerWeb.GalleryLive.GalleryTagLink}
-                    id={tag}
-                    tag={tag}
-                    folder={@folder}
-                    current_tags={@current_tags}
-                    selected_photo_ids={@selected_photo_ids}
-                    is_admin={@is_admin}
-                    is_recommended={true}
-                    is_selected={tag in @current_tags}
-                  /> --%>
                 </li>
-              <% end %>
-            </ul>
-          <% end %>
-          <%= if not Enum.empty?(@other_nav_tags) do %>
-            <ul class="py-2">
-              <%= for tag <- @other_nav_tags do %>
+              <% else %>
                 <li class="mr-2 content-visible-auto">
-                  <button class="underline text-blue-600 hover:text-blue-800 mr-2" phx-click="link_tag" phx-value-tag={tag} >
+                  <button
+                    class="underline text-blue-600 hover:text-blue-800 mr-2"
+                    phx-click="link_tag"
+                    phx-value-tag={tag}
+                  >
                     {tag}
                   </button>
-                  <%!-- <.live_component
-                    module={PhotoTaggerWeb.GalleryLive.GalleryTagLink}
-                    id={tag}
-                    tag={tag}
-                    folder={@folder}
-                    current_tags={@current_tags}
-                    selected_photo_ids={@selected_photo_ids}
-                    is_admin={@is_admin}
-                    is_recommended={false}
-                    is_selected={false}
-                  /> --%>
                 </li>
               <% end %>
-            </ul>
+              </ul>
+            <% end %>
           <% end %>
         </nav>
       <% end %>
@@ -98,23 +129,37 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
   end
 
   def mount(socket) do
-    {:ok, socket |> assign(:is_open, true)}
+    {:ok, socket |> assign(:is_open, true) |> assign(:selected_index, nil)}
   end
 
   def update(assigns, socket) do
-    {recommended_nav_tags, other_nav_tags} =
-      Enum.split_with(assigns.nav_tags, &(&1 in assigns.recommended_tags))
+    Logger.debug("NavPanel update: #{inspect(assigns)}")
 
+    # We're going to show current tags seperately from recommended tags
     recommended_nav_tags =
-      Enum.sort_by(recommended_nav_tags, fn tag ->
-        cond do
-          # show currently selected tags first
-          tag in assigns.current_tags -> 0
-          # tag in @recommended_tag_names -> 1 # then recommended tags
-          # then other tags
-          true -> 2
+      Enum.filter(assigns.recommended_tags, fn tag ->
+        tag not in assigns.current_tags
+      end)
+
+    indexed_tags =
+      Enum.group_by(assigns.nav_tags, fn tag ->
+        char = String.at(tag, 0) |> remove_diacritics() |> String.upcase()
+
+        if Regex.match?(~r/[A-Z]/, char) do
+          char
+        else
+          "#"
         end
       end)
+
+    index = case assigns.folder != Map.get(socket.assigns, :folder, nil) do
+        true ->
+          # if the folder changed, we need to reset the selected index
+          nil
+
+        false ->
+          socket.assigns.selected_index
+      end
 
     {:ok,
      socket
@@ -122,11 +167,27 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
      |> assign(:all_folders, assigns.all_folders)
      |> assign(:current_tags, assigns.current_tags)
      |> assign(:recommended_nav_tags, recommended_nav_tags)
-     |> assign(:other_nav_tags, other_nav_tags)
-     |> assign(:is_admin, assigns.is_admin)}
+     |> assign(:indexed_tags, indexed_tags)
+     |> assign(:is_admin, assigns.is_admin)
+     |> assign(:max_recommended_tags, 20)
+     |> assign(:selected_index, index)}
   end
 
   def handle_event("toggle_nav_panel", _, socket) do
     {:noreply, socket |> update(:is_open, fn is_open -> not is_open end)}
+  end
+
+  def handle_event("select_index", %{"index" => index}, socket) do
+    # Get the tags for the selected index
+    {:noreply, socket |> assign(:selected_index, index)}
+  end
+
+  # Util functions
+  defp remove_diacritics(string) do
+    string
+    # Decompose into base characters and diacritics
+    |> String.normalize(:nfkd)
+    # Remove diacritical marks (Unicode "Mark, Nonspacing")
+    |> String.replace(~r/\p{Mn}/u, "")
   end
 end

--- a/app/lib/photo_tagger_web/live/gallery_live/nav_panel.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/nav_panel.ex
@@ -44,6 +44,7 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
         <h2 class="">Tags</h2>
         <nav class="my-2 pl-2 list-none">
           <%= if not Enum.empty?(@current_tags) do %>
+            <h3 class="text-sm font-bold">Current tags</h3>
             <ul class="my-2">
               <%= for tag <- @current_tags do %>
                 <li class="mr-2">
@@ -62,6 +63,7 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
             and (@max_recommended_tags < 0
             or Enum.count(@recommended_nav_tags) <= @max_recommended_tags)
           do %>
+            <h3 class="text-sm font-bold">Recommended tags</h3>
             <ul class="my-2">
               <%= for tag <- @recommended_nav_tags do %>
                 <li class="mr-2">
@@ -76,7 +78,8 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
               <% end %>
             </ul>
           <% end %>
-          <ul id="index-selecors" class="flex flex-wrap mb-2">
+          <h3 class="text-sm font-bold">All tags</h3>
+          <ul id="index-selectors" class="flex flex-wrap my-2">
             <%= for {index, tags} <- Enum.sort(@indexed_tags) do %>
               <li>
                 <%= if Enum.empty?(tags) do %>
@@ -95,33 +98,33 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
               </li>
             <% end %>
           </ul>
-          <%= if @selected_index != nil do %>
-            <%= for tag <- Map.get(@indexed_tags, @selected_index) do %>
-              <ul>
-              <%= if tag in @current_tags or tag in @recommended_nav_tags do %>
-                <li class="mr-2 content-visible-auto">
-                  <.toggle_button
-                    selected={tag in @current_tags}
-                    phx-click="toggle_tag"
-                    phx-value-tag={tag}
-                  >
-                    {tag}
-                  </.toggle_button>
-                </li>
-              <% else %>
-                <li class="mr-2 content-visible-auto">
-                  <button
-                    class="underline text-blue-600 hover:text-blue-800 mr-2"
-                    phx-click="link_tag"
-                    phx-value-tag={tag}
-                  >
-                    {tag}
-                  </button>
-                </li>
+          <ul class="pb-96">
+            <%= if @selected_index != nil do %>
+              <%= for tag <- Map.get(@indexed_tags, @selected_index) do %>
+                <%= if tag in @current_tags or tag in @recommended_nav_tags do %>
+                  <li class="mr-2 content-visible-auto">
+                    <.toggle_button
+                      selected={tag in @current_tags}
+                      phx-click="toggle_tag"
+                      phx-value-tag={tag}
+                    >
+                      {tag}
+                    </.toggle_button>
+                  </li>
+                <% else %>
+                  <li class="mr-2 content-visible-auto">
+                    <button
+                      class="underline text-blue-600 hover:text-blue-800 mr-2"
+                      phx-click="link_tag"
+                      phx-value-tag={tag}
+                    >
+                      {tag}
+                    </button>
+                  </li>
+                <% end %>
               <% end %>
-              </ul>
             <% end %>
-          <% end %>
+          </ul>
         </nav>
       <% end %>
     </div>

--- a/app/lib/photo_tagger_web/live/gallery_live/nav_panel.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/nav_panel.ex
@@ -1,7 +1,8 @@
 defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
   use PhotoTaggerWeb, :live_component
 
-  # attr(:folder, :string, default: nil)
+  attr(:folder, :string, required: true)
+  attr(:all_folders, :list, required: true)
   attr(:nav_tags, :list, required: true)
   attr(:recommended_tags, :list, required: true)
   attr(:current_tags, :list, required: true)
@@ -28,6 +29,17 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
             <.icon name="hero-chevron-left" class="w-5 h-5" />
           </.button>
         </div>
+        <h2 class="pt-4">Folders</h2>
+        <form class="my-2" phx-change="change_folder">
+          <select value={@folder} name="folder" id="folder-select"  class="mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm">
+            <option value="">All folders</option>
+            <%= for folder <- @all_folders do %>
+              <option value={folder} selected={@folder == folder}>
+                {folder}
+              </option>
+            <% end %>
+          </select>
+        </form>
         <h2 class="">Tags</h2>
         <nav class="my-2 pl-2 list-none">
           <%= if not Enum.empty?(@recommended_nav_tags) do %>
@@ -106,6 +118,8 @@ defmodule PhotoTaggerWeb.GalleryLive.NavPanel do
 
     {:ok,
      socket
+     |> assign(:folder, assigns.folder)
+     |> assign(:all_folders, assigns.all_folders)
      |> assign(:current_tags, assigns.current_tags)
      |> assign(:recommended_nav_tags, recommended_nav_tags)
      |> assign(:other_nav_tags, other_nav_tags)


### PR DESCRIPTION
1. Moves folder dropdown to nav panel, and replaces it in breadcrumbs with a proper folder link.
2. Splits tag nav into three sections: selected tags, recommended tags (which only appears if there are 20 or less) and all folder tags, split up by starting letter.