### PR TITLE
Assign manual_order globally instead of per-folder

### DIFF
--- a/app/lib/mix/tasks/reorder_photos.ex
+++ b/app/lib/mix/tasks/reorder_photos.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.ReorderPhotos do
+  @moduledoc """
+  Reassigns manual_order for all photos based on upload time.
+
+  Oldest photos get the lowest order numbers. Photos with identical
+  upload times are sorted alphabetically by name.
+
+  ## Usage
+
+      mix reorder_photos
+  """
+
+  use Mix.Task
+
+  @shortdoc "Reorder all photos by upload time (oldest first)"
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    sql = """
+    UPDATE photos SET manual_order = sub.new_order
+    FROM (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY inserted_at ASC, name ASC) AS new_order
+      FROM photos
+    ) sub
+    WHERE photos.id = sub.id
+    """
+
+    case Ecto.Adapters.SQL.query(PhotoTagger.Repo, sql) do
+      {:ok, %{num_rows: count}} ->
+        Mix.shell().info("Updated manual_order for #{count} photos.")
+
+      {:error, reason} ->
+        Mix.shell().error("Failed to reorder photos: #{inspect(reason)}")
+    end
+  end
+end

--- a/app/lib/photo_tagger/gallery.ex
+++ b/app/lib/photo_tagger/gallery.ex
@@ -386,14 +386,7 @@ defmodule PhotoTagger.Gallery do
 
     # Auto-assign manual_order if not provided
     attrs =
-      if Map.has_key?(attrs, "folder_id") and not Map.has_key?(attrs, "manual_order") do
-        # Convert folder_id to integer if it's a string (from form params)
-        folder_id =
-          case attrs["folder_id"] do
-            id when is_integer(id) -> id
-            id when is_binary(id) -> String.to_integer(id)
-          end
-
+      if not Map.has_key?(attrs, "manual_order") do
         next_order = get_next_manual_order()
         Map.put(attrs, "manual_order", next_order)
       else

--- a/app/lib/photo_tagger/gallery.ex
+++ b/app/lib/photo_tagger/gallery.ex
@@ -75,29 +75,12 @@ defmodule PhotoTagger.Gallery do
   end
 
   @doc """
-  Gets the next available manual_order position for a folder.
-  Returns 1 if no photos exist in the folder, otherwise max + 1.
-  """
-  def get_next_manual_order(folder_id) when is_integer(folder_id) do
-    max_order =
-      from(p in Photo,
-        where: p.folder_id == ^folder_id,
-        select: max(p.manual_order)
-      )
-      |> Repo.one()
-
-    case max_order do
-      nil -> 1
-      n -> n + 1
-    end
-  end
-
-  @doc """
   Gets the next available manual_order for all photos.
   Returns 1 if no photos exist, otherwise max + 1.
   """
   def get_next_manual_order() do
-    max_order = from(p in Photo, select: max(p.manual_order)) 
+    max_order =
+      from(p in Photo, select: max(p.manual_order))
       |> Repo.one()
 
     case max_order do

--- a/app/lib/photo_tagger/gallery.ex
+++ b/app/lib/photo_tagger/gallery.ex
@@ -92,6 +92,20 @@ defmodule PhotoTagger.Gallery do
     end
   end
 
+  @doc """
+  Gets the next available manual_order for all photos.
+  Returns 1 if no photos exist, otherwise max + 1.
+  """
+  def get_next_manual_order() do
+    max_order = from(p in Photo, select: max(p.manual_order)) 
+      |> Repo.one()
+
+    case max_order do
+      nil -> 1
+      n -> n + 1
+    end
+  end
+
   defp list_photos_query(sort, sort_direction) do
     from(p in Photo,
       as: :photo,
@@ -380,7 +394,7 @@ defmodule PhotoTagger.Gallery do
             id when is_binary(id) -> String.to_integer(id)
           end
 
-        next_order = get_next_manual_order(folder_id)
+        next_order = get_next_manual_order()
         Map.put(attrs, "manual_order", next_order)
       else
         attrs
@@ -691,7 +705,7 @@ defmodule PhotoTagger.Gallery do
           is_public: photo.is_public,
           image_last_modified: photo.image_last_modified,
           original_photo_id: photo.id,
-          manual_order: get_next_manual_order(target_folder_id)
+          manual_order: get_next_manual_order()
         },
         [
           :name,

--- a/app/test/photo_tagger/gallery_test.exs
+++ b/app/test/photo_tagger/gallery_test.exs
@@ -567,18 +567,6 @@ defmodule PhotoTagger.GalleryTest do
       assert photo_ids == Enum.sort([photo1.id, photo2.id])
     end
 
-    test "get_next_manual_order/1 returns 1 for empty folder", %{folder: _folder} do
-      empty_folder = folder_fixture(%{name: "empty_folder"})
-      assert Gallery.get_next_manual_order(empty_folder.id) == 1
-    end
-
-    test "get_next_manual_order/1 returns max + 1 for folder with photos", %{folder: folder} do
-      _photo1 = photo_fixture(%{folder_id: folder.id, manual_order: 5})
-      _photo2 = photo_fixture(%{folder_id: folder.id, manual_order: 3})
-
-      assert Gallery.get_next_manual_order(folder.id) == 6
-    end
-
     test "get_next_manual_order/0 returns 1 when no photos exist" do
       assert Gallery.get_next_manual_order() == 1
     end

--- a/app/test/photo_tagger/gallery_test.exs
+++ b/app/test/photo_tagger/gallery_test.exs
@@ -578,6 +578,27 @@ defmodule PhotoTagger.GalleryTest do
 
       assert Gallery.get_next_manual_order(folder.id) == 6
     end
+
+    test "get_next_manual_order/0 returns 1 when no photos exist" do
+      assert Gallery.get_next_manual_order() == 1
+    end
+
+    test "get_next_manual_order/0 returns max + 1 across all folders", %{folder: folder} do
+      other_folder = folder_fixture(%{name: "other_folder"})
+      _photo1 = photo_fixture(%{folder_id: folder.id, manual_order: 3})
+      _photo2 = photo_fixture(%{folder_id: other_folder.id, manual_order: 7})
+
+      assert Gallery.get_next_manual_order() == 8
+    end
+
+    test "get_next_manual_order/0 ignores folder boundaries", %{folder: folder} do
+      other_folder = folder_fixture(%{name: "other_folder"})
+      _photo1 = photo_fixture(%{folder_id: folder.id, manual_order: 10})
+      _photo2 = photo_fixture(%{folder_id: other_folder.id, manual_order: 2})
+
+      # Should return 11, not 3 — looks at all photos globally
+      assert Gallery.get_next_manual_order() == 11
+    end
   end
 
   describe "related tags" do

--- a/app/test/support/fixtures/gallery_fixtures.ex
+++ b/app/test/support/fixtures/gallery_fixtures.ex
@@ -96,7 +96,7 @@ defmodule PhotoTagger.GalleryFixtures do
 
     # Get next manual order if not provided
     manual_order =
-      Map.get_lazy(attrs, :manual_order, fn -> Gallery.get_next_manual_order(folder_id) end)
+      Map.get_lazy(attrs, :manual_order, fn -> Gallery.get_next_manual_order() end)
 
     name = Map.get(attrs, :name, unique_photo_name())
 


### PR DESCRIPTION
## Summary
- Change `get_next_manual_order` to assign order across all photos globally, so curated ordering is consistent when viewing all folders together
- Simplify `create_photo` by removing the now-unnecessary folder_id parsing for order assignment
- Add `mix reorder_photos` task to backfill existing photos' `manual_order` by upload time (oldest first, alphabetical tiebreak) using a single SQL `ROW_NUMBER()` query
- Add tests for the new global `get_next_manual_order/0`

## Test plan
- [x] New unit tests for `get_next_manual_order/0` pass (empty DB, cross-folder max)
- [ ] Run `mix reorder_photos` in dev and verify photos are ordered by upload time
- [ ] Verify gallery UI shows correct ordering when viewing all photos and individual folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)