### PR TITLE
Add pg_size select dropdown to gallery header

### DIFF
--- a/app/lib/mix/tasks/reorder_photos.ex
+++ b/app/lib/mix/tasks/reorder_photos.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.ReorderPhotos do
+  @moduledoc """
+  Reassigns manual_order for all photos based on upload time.
+
+  Oldest photos get the lowest order numbers. Photos with identical
+  upload times are sorted alphabetically by name.
+
+  ## Usage
+
+      mix reorder_photos
+  """
+
+  use Mix.Task
+
+  @shortdoc "Reorder all photos by upload time (oldest first)"
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    sql = """
+    UPDATE photos SET manual_order = sub.new_order
+    FROM (
+      SELECT id, ROW_NUMBER() OVER (ORDER BY inserted_at ASC, name ASC) AS new_order
+      FROM photos
+    ) sub
+    WHERE photos.id = sub.id
+    """
+
+    case Ecto.Adapters.SQL.query(PhotoTagger.Repo, sql) do
+      {:ok, %{num_rows: count}} ->
+        Mix.shell().info("Updated manual_order for #{count} photos.")
+
+      {:error, reason} ->
+        Mix.shell().error("Failed to reorder photos: #{inspect(reason)}")
+    end
+  end
+end

--- a/app/lib/photo_tagger/gallery.ex
+++ b/app/lib/photo_tagger/gallery.ex
@@ -386,14 +386,7 @@ defmodule PhotoTagger.Gallery do
 
     # Auto-assign manual_order if not provided
     attrs =
-      if Map.has_key?(attrs, "folder_id") and not Map.has_key?(attrs, "manual_order") do
-        # Convert folder_id to integer if it's a string (from form params)
-        folder_id =
-          case attrs["folder_id"] do
-            id when is_integer(id) -> id
-            id when is_binary(id) -> String.to_integer(id)
-          end
-
+      if not Map.has_key?(attrs, "manual_order") do
         next_order = get_next_manual_order()
         Map.put(attrs, "manual_order", next_order)
       else

--- a/app/lib/photo_tagger/gallery.ex
+++ b/app/lib/photo_tagger/gallery.ex
@@ -75,29 +75,12 @@ defmodule PhotoTagger.Gallery do
   end
 
   @doc """
-  Gets the next available manual_order position for a folder.
-  Returns 1 if no photos exist in the folder, otherwise max + 1.
-  """
-  def get_next_manual_order(folder_id) when is_integer(folder_id) do
-    max_order =
-      from(p in Photo,
-        where: p.folder_id == ^folder_id,
-        select: max(p.manual_order)
-      )
-      |> Repo.one()
-
-    case max_order do
-      nil -> 1
-      n -> n + 1
-    end
-  end
-
-  @doc """
   Gets the next available manual_order for all photos.
   Returns 1 if no photos exist, otherwise max + 1.
   """
   def get_next_manual_order() do
-    max_order = from(p in Photo, select: max(p.manual_order)) 
+    max_order =
+      from(p in Photo, select: max(p.manual_order))
       |> Repo.one()
 
     case max_order do

--- a/app/lib/photo_tagger/gallery.ex
+++ b/app/lib/photo_tagger/gallery.ex
@@ -92,6 +92,20 @@ defmodule PhotoTagger.Gallery do
     end
   end
 
+  @doc """
+  Gets the next available manual_order for all photos.
+  Returns 1 if no photos exist, otherwise max + 1.
+  """
+  def get_next_manual_order() do
+    max_order = from(p in Photo, select: max(p.manual_order)) 
+      |> Repo.one()
+
+    case max_order do
+      nil -> 1
+      n -> n + 1
+    end
+  end
+
   defp list_photos_query(sort, sort_direction) do
     from(p in Photo,
       as: :photo,
@@ -380,7 +394,7 @@ defmodule PhotoTagger.Gallery do
             id when is_binary(id) -> String.to_integer(id)
           end
 
-        next_order = get_next_manual_order(folder_id)
+        next_order = get_next_manual_order()
         Map.put(attrs, "manual_order", next_order)
       else
         attrs
@@ -691,7 +705,7 @@ defmodule PhotoTagger.Gallery do
           is_public: photo.is_public,
           image_last_modified: photo.image_last_modified,
           original_photo_id: photo.id,
-          manual_order: get_next_manual_order(target_folder_id)
+          manual_order: get_next_manual_order()
         },
         [
           :name,

--- a/app/lib/photo_tagger_web/live/gallery_live/gallery_tag_link.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/gallery_tag_link.ex
@@ -11,6 +11,7 @@ defmodule PhotoTaggerWeb.GalleryLive.GalleryTagLink do
   attr(:is_admin, :boolean, default: false)
   attr(:is_recommended, :boolean, default: false)
   attr(:is_selected, :boolean, default: false)
+  attr(:pg_size, :integer, default: nil)
 
   def render(assigns) do
     ~H"""
@@ -50,7 +51,8 @@ defmodule PhotoTaggerWeb.GalleryLive.GalleryTagLink do
         assigns.selected_photo_ids,
         tags_list,
         assigns.exclude_tags,
-        assigns.is_admin
+        assigns.is_admin,
+        pg_size: assigns.pg_size
       )
 
     {:ok,

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -45,6 +45,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             sort={@sort}
             sort_direction={@sort_direction}
             show_visibility_outlines={@show_visibility_outlines}
+            pg_size={@pg_size}
           />
           <%!-- <.live_component
             id="gallery-panel"
@@ -83,6 +84,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                 is_admin={@is_admin}
                 sort={@sort}
                 sort_direction={@sort_direction}
+                pg_size={@pg_size}
               />
             <% [] -> %>
               <p class="text-center">Select a photo to view details</p>
@@ -456,6 +458,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:is_admin, :boolean, required: true)
   attr(:sort, :atom, default: nil)
   attr(:sort_direction, :atom, default: nil)
+  attr(:pg_size, :integer, default: nil)
   slot(:inner_block)
 
   def toggle_tag_button(assigns) do
@@ -483,10 +486,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           tags_list,
           new_exclude_tags,
           assigns.is_admin,
-          nil,
-          assigns.sort,
-          nil,
-          assigns.sort_direction
+          sort: assigns.sort,
+          sort_direction: assigns.sort_direction,
+          pg_size: assigns.pg_size
         )
       )
 
@@ -508,6 +510,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:sort, :atom, default: :manual)
   attr(:sort_direction, :atom, default: :desc)
   attr(:show_visibility_outlines, :boolean, default: false)
+  attr(:pg_size, :integer, default: @default_pg_size)
 
   def gallery_header(assigns) do
     breadcrumb_tags = Enum.scan(assigns.tags, [], fn tag, acc -> [tag | acc] end)
@@ -522,7 +525,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             <.link
               id="breadcrumb-folder"
               aria-current={if(length(@breadcrumb_tags) == 0, do: "page", else: "false")}
-              patch={Util.build_url(@folder, [], [], [], @is_admin)}
+              patch={Util.build_url(@folder, [], [], [], @is_admin, pg_size: @pg_size)}
             >
               {@folder || "All folders"}
             </.link>
@@ -535,7 +538,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
               />
               <.link
                 aria-current={if(index == length(@breadcrumb_tags) - 1, do: "page", else: "false")}
-                patch={Util.build_url(@folder, [], Enum.reverse(tags), [], @is_admin)}
+                patch={Util.build_url(@folder, [], Enum.reverse(tags), [], @is_admin, pg_size: @pg_size)}
               >
                 #{tag}
               </.link>
@@ -817,6 +820,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   attr(:all_folders, :list, required: true)
   attr(:sort, :atom, default: nil)
   attr(:sort_direction, :atom, default: nil)
+  attr(:pg_size, :integer, default: @default_pg_size)
 
   def photo(assigns) do
     assigns = assign(assigns, :folder_is_active, assigns.folder == assigns.photo.folder.name)
@@ -853,7 +857,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         <div class="flex items-center gap-2">
           <.link
             class="data-[active]:font-bold"
-            patch={Util.build_url(@photo.folder.name, [@photo.id], @tags, @exclude_tags, @is_admin)}
+            patch={Util.build_url(@photo.folder.name, [@photo.id], @tags, @exclude_tags, @is_admin, pg_size: @pg_size)}
             data-active={@folder_is_active}
           >
             {@photo.folder.name}
@@ -876,7 +880,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                   [@photo.original_photo.id],
                   @tags,
                   @exclude_tags,
-                  @is_admin
+                  @is_admin,
+                  pg_size: @pg_size
                 )
               }
               class="underline hover:text-purple-800"
@@ -898,7 +903,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
           <%= for {listing, index} <- Enum.with_index(@cross_listings_with_folders) do %>
             <.link
               patch={
-                Util.build_url(listing.folder.name, [listing.id], @tags, @exclude_tags, @is_admin)
+                Util.build_url(listing.folder.name, [listing.id], @tags, @exclude_tags, @is_admin, pg_size: @pg_size)
               }
               class="text-purple-600 hover:text-purple-800 underline"
             >
@@ -923,6 +928,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                   is_admin={@is_admin}
                   sort={@sort}
                   sort_direction={@sort_direction}
+                  pg_size={@pg_size}
                 >
                   #{tag.name}
                 </.toggle_tag_button>
@@ -934,10 +940,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                     [tag.name],
                     @exclude_tags,
                     @is_admin,
-                    nil,
-                    @sort,
-                    nil,
-                    @sort_direction
+                    sort: @sort,
+                    sort_direction: @sort_direction,
+                    pg_size: @pg_size
                   )
                 }>
                   #{tag.name}
@@ -1094,7 +1099,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
             <%= for listing <- @cross_listings_with_folders do %>
               <li>
                 <.link
-                  patch={Util.build_url(listing.folder.name, [listing.id], [], [], @is_admin)}
+                  patch={Util.build_url(listing.folder.name, [listing.id], [], [], @is_admin, pg_size: @pg_size)}
                   class="text-blue-600 hover:underline"
                 >
                   {listing.folder.name}
@@ -1148,7 +1153,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       <:item title="Drift">
         <.link
           class="text-blue-600 hover:text-blue-800"
-          patch={Util.build_url(@folder, [@photo.id], @tags, @exclude_tags, false, "drift")}
+          patch={Util.build_url(@folder, [@photo.id], @tags, @exclude_tags, false, tail: "drift")}
         >
           drift<.icon name="hero-arrow-up-right" class="w-3 h-3 ml-1" />
         </.link>
@@ -1373,10 +1378,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           socket.assigns.pg,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           pg: socket.assigns.pg,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )
      |> assign(:last_selected_photo_id, photo_id)}
@@ -1392,10 +1397,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           socket.assigns.pg,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           pg: socket.assigns.pg,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )
      |> assign(:last_selected_photo_id, photo_id)}
@@ -1427,10 +1432,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )
      |> assign(:last_selected_photo_id, photo_id)}
@@ -1498,10 +1502,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                  socket.assigns.tags,
                  socket.assigns.exclude_tags,
                  socket.assigns.is_admin,
-                 nil,
-                 socket.assigns.sort,
-                 nil,
-                 socket.assigns.sort_direction
+                 sort: socket.assigns.sort,
+                 sort_direction: socket.assigns.sort_direction,
+                 pg_size: socket.assigns.pg_size
                )
            )
            |> assign(:last_selected_photo_id, photo_id)}
@@ -1872,10 +1875,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )
      |> put_flash(:info, "Photo deleted successfully.")}
@@ -1901,10 +1903,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )
      |> put_flash(:info, "Photos deleted successfully.")}
@@ -1956,7 +1957,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
                [],
                socket.assigns.tags,
                socket.assigns.exclude_tags,
-               socket.assigns.is_admin
+               socket.assigns.is_admin,
+               pg_size: socket.assigns.pg_size
              )
          )}
 
@@ -2033,8 +2035,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           sort_atom
+           sort: sort_atom,
+           pg_size: socket.assigns.pg_size
          )
      )}
   end
@@ -2051,10 +2053,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           new_direction
+           sort: socket.assigns.sort,
+           sort_direction: new_direction,
+           pg_size: socket.assigns.pg_size
          )
      )}
   end
@@ -2075,10 +2076,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            [],
            [],
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )}
   end
@@ -2099,10 +2099,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            new_tags,
            Enum.filter(socket.assigns.exclude_tags, fn t -> t != tag end),
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )}
   end
@@ -2117,10 +2116,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            [tag],
            Enum.filter(socket.assigns.exclude_tags, fn t -> t != tag end),
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )}
   end
@@ -2141,10 +2139,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            Enum.filter(socket.assigns.tags, fn t -> t != tag end),
            new_exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           nil,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )}
   end
@@ -2161,10 +2158,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
            socket.assigns.tags,
            socket.assigns.exclude_tags,
            socket.assigns.is_admin,
-           nil,
-           socket.assigns.sort,
-           pg,
-           socket.assigns.sort_direction
+           sort: socket.assigns.sort,
+           pg: pg,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: socket.assigns.pg_size
          )
      )
      |> push_event("scroll_to_top", %{selector: "#gallery-section"})}

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -225,11 +225,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
       (Map.get(params, "pg") || Map.get(params, "page") || "1")
       |> Util.safe_integer_parse(1)
 
-    prev_pg_size = Map.get(socket.assigns, :pg_size, @default_pg_size)
-
     pg_size =
-      Map.get(params, "pg_size", Integer.to_string(prev_pg_size))
-      |> Util.safe_integer_parse(prev_pg_size)
+      Map.get(params, "pg_size", Integer.to_string(@default_pg_size))
+      |> Util.safe_integer_parse(@default_pg_size)
 
     socket =
       assign(socket, %{pg: pg, pg_size: pg_size, sort: sort, sort_direction: sort_direction})
@@ -514,7 +512,12 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
   def gallery_header(assigns) do
     breadcrumb_tags = Enum.scan(assigns.tags, [], fn tag, acc -> [tag | acc] end)
-    assigns = assign(assigns, :breadcrumb_tags, breadcrumb_tags)
+    show_pg_size_select = assigns.pg_size != @default_pg_size or assigns.item_count > @default_pg_size
+
+    assigns =
+      assigns
+      |> assign(:breadcrumb_tags, breadcrumb_tags)
+      |> assign(:show_pg_size_select, show_pg_size_select)
 
     ~H"""
     <div class="md:flex sticky top-0 bg-white z-50">
@@ -565,6 +568,20 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         </div>
         <div class="flex-none mr-3 lg:ml-3">
           <p class="font-bold">{"#{@item_count}"}<span class="hidden md:inline">{" items"}</span></p>
+        </div>
+        <div :if={@show_pg_size_select} class="flex-none pr-3">
+          <form phx-change="change_pg_size" class="flex items-center">
+            <label class="sr-only lg:not-sr-only text-sm mr-2">Per page:</label>
+            <select
+              id="pg-size-select"
+              name="pg_size"
+              class="text-sm rounded-lg border-gray-300 ml-1 py-1 pl-2 pr-8"
+            >
+              <option value="500" selected={@pg_size == 500}>500</option>
+              <option value="1000" selected={@pg_size == 1000}>1000</option>
+              <option value="2000" selected={@pg_size == 2000}>2000</option>
+            </select>
+          </form>
         </div>
         <div class="flex-none pr-3">
           <form phx-change="change_sort" class="flex items-center">
@@ -2165,6 +2182,26 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
          )
      )
      |> push_event("scroll_to_top", %{selector: "#gallery-section"})}
+  end
+
+  def handle_event("change_pg_size", %{"pg_size" => pg_size}, socket) do
+    pg_size = Util.safe_integer_parse(pg_size, @default_pg_size)
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         Util.build_url(
+           socket.assigns.folder,
+           socket.assigns.selected_photo_ids,
+           socket.assigns.tags,
+           socket.assigns.exclude_tags,
+           socket.assigns.is_admin,
+           sort: socket.assigns.sort,
+           pg: 1,
+           sort_direction: socket.assigns.sort_direction,
+           pg_size: pg_size
+         )
+     )}
   end
 
   ## Utility functions

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -228,6 +228,8 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
     pg_size =
       Map.get(params, "pg_size", Integer.to_string(@default_pg_size))
       |> Util.safe_integer_parse(@default_pg_size)
+      |> max(1)
+      |> min(3000)
 
     socket =
       assign(socket, %{pg: pg, pg_size: pg_size, sort: sort, sort_direction: sort_direction})
@@ -571,7 +573,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         </div>
         <div :if={@show_pg_size_select} class="flex-none pr-3">
           <form phx-change="change_pg_size" class="flex items-center">
-            <label class="sr-only lg:not-sr-only text-sm mr-2">Per page:</label>
+            <label for="pg-size-select" class="sr-only lg:not-sr-only text-sm mr-2">Per page:</label>
             <select
               id="pg-size-select"
               name="pg_size"
@@ -2185,7 +2187,10 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
   end
 
   def handle_event("change_pg_size", %{"pg_size" => pg_size}, socket) do
-    pg_size = Util.safe_integer_parse(pg_size, @default_pg_size)
+    pg_size =
+      Util.safe_integer_parse(pg_size, @default_pg_size)
+      |> max(1)
+      |> min(3000)
 
     {:noreply,
      push_patch(socket,

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -12,7 +12,7 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
 
   require Logger
 
-  @default_pg_size 100
+  @default_pg_size 500
 
   def render(assigns) do
     ~H"""

--- a/app/lib/photo_tagger_web/live/gallery_live/main.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/main.ex
@@ -219,11 +219,9 @@ defmodule PhotoTaggerWeb.GalleryLive.Main do
         _ -> :desc
       end
 
-    prev_pg = Map.get(socket.assigns, :pg, 1)
-
     pg =
-      (Map.get(params, "pg") || Map.get(params, "page") || Integer.to_string(prev_pg))
-      |> Util.safe_integer_parse(prev_pg)
+      (Map.get(params, "pg") || Map.get(params, "page") || "1")
+      |> Util.safe_integer_parse(1)
 
     prev_pg_size = Map.get(socket.assigns, :pg_size, @default_pg_size)
 

--- a/app/lib/photo_tagger_web/live/gallery_live/util.ex
+++ b/app/lib/photo_tagger_web/live/gallery_live/util.ex
@@ -1,17 +1,15 @@
 defmodule PhotoTaggerWeb.GalleryLive.Util do
   require Logger
 
-  def build_url(
-        folder,
-        selected_photo_ids,
-        tags,
-        exclude_tags,
-        is_admin,
-        tail \\ nil,
-        sort \\ nil,
-        pg \\ nil,
-        sort_direction \\ nil
-      ) do
+  @default_pg_size 500
+
+  def build_url(folder, selected_photo_ids, tags, exclude_tags, is_admin, opts \\ []) do
+    tail = Keyword.get(opts, :tail)
+    sort = Keyword.get(opts, :sort)
+    pg = Keyword.get(opts, :pg)
+    sort_direction = Keyword.get(opts, :sort_direction)
+    pg_size = Keyword.get(opts, :pg_size)
+
     {photo_id, selected_photo_ids} =
       case selected_photo_ids do
         [photo_id] -> {photo_id, []}
@@ -46,15 +44,12 @@ defmodule PhotoTaggerWeb.GalleryLive.Util do
       |> Map.put(:selected_photos, selected_photo_ids)
       |> then(fn q ->
         case sort do
-          # Manual mode is default, so it is not added to url
-          # :manual -> Map.put(q, :sort, "manual")
           :date -> Map.put(q, :sort, "date")
           _ -> q
         end
       end)
       |> then(fn q ->
         case sort_direction do
-          # Descending is default, so it is not added to url
           :asc -> Map.put(q, :sort_direction, "asc")
           _ -> q
         end
@@ -64,6 +59,13 @@ defmodule PhotoTaggerWeb.GalleryLive.Util do
           nil -> q
           1 -> q
           _ -> Map.put(q, :pg, pg)
+        end
+      end)
+      |> then(fn q ->
+        case pg_size do
+          nil -> q
+          @default_pg_size -> q
+          _ -> Map.put(q, :pg_size, pg_size)
         end
       end)
       |> Plug.Conn.Query.encode()

--- a/app/test/photo_tagger/gallery_test.exs
+++ b/app/test/photo_tagger/gallery_test.exs
@@ -567,18 +567,6 @@ defmodule PhotoTagger.GalleryTest do
       assert photo_ids == Enum.sort([photo1.id, photo2.id])
     end
 
-    test "get_next_manual_order/1 returns 1 for empty folder", %{folder: _folder} do
-      empty_folder = folder_fixture(%{name: "empty_folder"})
-      assert Gallery.get_next_manual_order(empty_folder.id) == 1
-    end
-
-    test "get_next_manual_order/1 returns max + 1 for folder with photos", %{folder: folder} do
-      _photo1 = photo_fixture(%{folder_id: folder.id, manual_order: 5})
-      _photo2 = photo_fixture(%{folder_id: folder.id, manual_order: 3})
-
-      assert Gallery.get_next_manual_order(folder.id) == 6
-    end
-
     test "get_next_manual_order/0 returns 1 when no photos exist" do
       assert Gallery.get_next_manual_order() == 1
     end

--- a/app/test/photo_tagger/gallery_test.exs
+++ b/app/test/photo_tagger/gallery_test.exs
@@ -578,6 +578,27 @@ defmodule PhotoTagger.GalleryTest do
 
       assert Gallery.get_next_manual_order(folder.id) == 6
     end
+
+    test "get_next_manual_order/0 returns 1 when no photos exist" do
+      assert Gallery.get_next_manual_order() == 1
+    end
+
+    test "get_next_manual_order/0 returns max + 1 across all folders", %{folder: folder} do
+      other_folder = folder_fixture(%{name: "other_folder"})
+      _photo1 = photo_fixture(%{folder_id: folder.id, manual_order: 3})
+      _photo2 = photo_fixture(%{folder_id: other_folder.id, manual_order: 7})
+
+      assert Gallery.get_next_manual_order() == 8
+    end
+
+    test "get_next_manual_order/0 ignores folder boundaries", %{folder: folder} do
+      other_folder = folder_fixture(%{name: "other_folder"})
+      _photo1 = photo_fixture(%{folder_id: folder.id, manual_order: 10})
+      _photo2 = photo_fixture(%{folder_id: other_folder.id, manual_order: 2})
+
+      # Should return 11, not 3 — looks at all photos globally
+      assert Gallery.get_next_manual_order() == 11
+    end
   end
 
   describe "related tags" do

--- a/app/test/photo_tagger_web/live/gallery_live/main_test.exs
+++ b/app/test/photo_tagger_web/live/gallery_live/main_test.exs
@@ -1611,6 +1611,79 @@ defmodule PhotoTaggerWeb.GalleryLive.MainTest do
     end
   end
 
+  describe "REGRESSION: page resets to 1 when gallery filters change" do
+    setup %{conn: conn} do
+      folder = folder_fixture(%{name: "ResetFolder"})
+      folder2 = folder_fixture(%{name: "OtherFolder"})
+      tag = tag_fixture(%{name: "resettest"})
+
+      photos =
+        for i <- 1..15, do: photo_fixture(%{folder_id: folder.id, name: "rp#{i}.jpg"})
+
+      _photo2 = photo_fixture(%{folder_id: folder2.id, name: "other.jpg"})
+
+      Gallery.add_tag_to_photo(hd(photos), tag.name)
+
+      %{conn: conn, folder: folder, folder2: folder2, tag: tag}
+    end
+
+    test "change_sort resets page to 1 with correct photo count", %{conn: conn, folder: folder} do
+      {:ok, view, _html} = live(conn, ~p"/admin/folders/#{folder.name}?pg_size=10")
+      render_click(view, "toggle_collapse_groups", %{})
+
+      html = render_click(view, "change_page", %{"pg" => "2"})
+      assert extract_page_number(html) == 2
+      assert length(extract_photo_ids_from_gallery(html)) == 5
+
+      html = render_click(view, "change_sort", %{"sort" => "date"})
+      assert extract_page_number(html) == 1
+      assert length(extract_photo_ids_from_gallery(html)) == 10
+    end
+
+    test "toggle_sort_direction resets page to 1 with correct photo count", %{conn: conn, folder: folder} do
+      {:ok, view, _html} = live(conn, ~p"/admin/folders/#{folder.name}?pg_size=10")
+      render_click(view, "toggle_collapse_groups", %{})
+
+      html = render_click(view, "change_page", %{"pg" => "2"})
+      assert extract_page_number(html) == 2
+      assert length(extract_photo_ids_from_gallery(html)) == 5
+
+      html = render_click(view, "toggle_sort_direction", %{})
+      assert extract_page_number(html) == 1
+      assert length(extract_photo_ids_from_gallery(html)) == 10
+    end
+
+    test "toggle_tag resets page to 1", %{conn: conn, folder: folder, tag: tag} do
+      {:ok, view, _html} = live(conn, ~p"/admin/folders/#{folder.name}?pg_size=10")
+
+      html = render_click(view, "change_page", %{"pg" => "2"})
+      assert extract_page_number(html) == 2
+
+      html = render_click(view, "toggle_tag", %{"tag" => tag.name})
+      assert extract_page_number(html) == 1
+      # Only 1 photo has the tag, so only 1 should appear
+      render_click(view, "toggle_collapse_groups", %{})
+      html = render(view)
+      assert length(extract_photo_ids_from_gallery(html)) == 1
+    end
+
+    test "change_folder resets page to 1 with correct photo count", %{conn: conn, folder: folder, folder2: folder2} do
+      {:ok, view, _html} = live(conn, ~p"/admin/folders/#{folder.name}?pg_size=10")
+      render_click(view, "toggle_collapse_groups", %{})
+
+      html = render_click(view, "change_page", %{"pg" => "2"})
+      assert extract_page_number(html) == 2
+      assert length(extract_photo_ids_from_gallery(html)) == 5
+
+      html = render_click(view, "change_folder", %{"folder" => folder2.name})
+      assert extract_page_number(html) == 1
+      # OtherFolder has only 1 photo
+      render_click(view, "toggle_collapse_groups", %{})
+      html = render(view)
+      assert length(extract_photo_ids_from_gallery(html)) == 1
+    end
+  end
+
   describe "change_page - scroll behavior" do
     @describetag skip: "Requires assert_push_event/3, unavailable in LiveView 1.0"
     test "triggers scroll to top when changing pages", %{conn: conn} do

--- a/app/test/photo_tagger_web/live/gallery_live/util_test.exs
+++ b/app/test/photo_tagger_web/live/gallery_live/util_test.exs
@@ -7,7 +7,7 @@ defmodule PhotoTaggerWeb.GalleryLive.UtilTest do
 
   alias PhotoTaggerWeb.GalleryLive.Util
 
-  describe "build_url/8" do
+  describe "build_url/6" do
     test "generates correct public URLs without admin prefix" do
       url = Util.build_url(nil, [], [], [], false)
       assert url == "/photos"
@@ -74,9 +74,9 @@ defmodule PhotoTaggerWeb.GalleryLive.UtilTest do
     end
 
     test "includes sort param only when :date" do
-      url_manual = Util.build_url(nil, [], [], [], false, nil, :manual)
-      url_date = Util.build_url(nil, [], [], [], false, nil, :date)
-      url_nil = Util.build_url(nil, [], [], [], false, nil, nil)
+      url_manual = Util.build_url(nil, [], [], [], false, sort: :manual)
+      url_date = Util.build_url(nil, [], [], [], false, sort: :date)
+      url_nil = Util.build_url(nil, [], [], [], false)
 
       refute url_manual =~ "sort"
       assert url_date =~ "sort=date"
@@ -84,10 +84,10 @@ defmodule PhotoTaggerWeb.GalleryLive.UtilTest do
     end
 
     test "includes pg param only when greater than 1" do
-      url_nil = Util.build_url(nil, [], [], [], false, nil, nil, nil)
-      url_page1 = Util.build_url(nil, [], [], [], false, nil, nil, 1)
-      url_page2 = Util.build_url(nil, [], [], [], false, nil, nil, 2)
-      url_page5 = Util.build_url(nil, [], [], [], false, nil, nil, 5)
+      url_nil = Util.build_url(nil, [], [], [], false)
+      url_page1 = Util.build_url(nil, [], [], [], false, pg: 1)
+      url_page2 = Util.build_url(nil, [], [], [], false, pg: 2)
+      url_page5 = Util.build_url(nil, [], [], [], false, pg: 5)
 
       refute url_nil =~ "pg"
       refute url_page1 =~ "pg"
@@ -96,17 +96,17 @@ defmodule PhotoTaggerWeb.GalleryLive.UtilTest do
     end
 
     test "handles tail parameter for drift mode" do
-      url = Util.build_url("vacation", [123], [], [], false, "drift")
+      url = Util.build_url("vacation", [123], [], [], false, tail: "drift")
       assert url == "/folders/vacation/photos/123/drift"
     end
 
     test "handles tail parameter without folder" do
-      url = Util.build_url(nil, [789], [], [], false, "drift")
+      url = Util.build_url(nil, [789], [], [], false, tail: "drift")
       assert url == "/photos/789/drift"
     end
 
     test "combines admin prefix with tail" do
-      url = Util.build_url("album", [42], [], [], true, "drift")
+      url = Util.build_url("album", [42], [], [], true, tail: "drift")
       assert url == "/admin/folders/album/photos/42/drift"
     end
 
@@ -118,9 +118,8 @@ defmodule PhotoTaggerWeb.GalleryLive.UtilTest do
           ["beach"],
           ["indoor"],
           true,
-          nil,
-          :date,
-          3
+          sort: :date,
+          pg: 3
         )
 
       assert url =~ "/admin/folders/summer"

--- a/app/test/support/fixtures/gallery_fixtures.ex
+++ b/app/test/support/fixtures/gallery_fixtures.ex
@@ -96,7 +96,7 @@ defmodule PhotoTagger.GalleryFixtures do
 
     # Get next manual order if not provided
     manual_order =
-      Map.get_lazy(attrs, :manual_order, fn -> Gallery.get_next_manual_order(folder_id) end)
+      Map.get_lazy(attrs, :manual_order, fn -> Gallery.get_next_manual_order() end)
 
     name = Map.get(attrs, :name, unique_photo_name())
 


### PR DESCRIPTION
## Summary
- Adds a "Per page" select dropdown (500/1000/2000) to the gallery header controls
- Only visible when item count exceeds the default (500) or pg_size is already non-default
- Selecting a value updates the URL and resets to page 1
- Refactors `build_url` to use keyword opts instead of positional args, threads `pg_size` through all navigation links
- Fixes `handle_params` to fall back to `@default_pg_size` instead of previous socket value when `pg_size` is absent from URL
- Makes `get_next_manual_order` global (not per-folder), adds reorder mix task

## Test plan
- [ ] Browse gallery with >500 items — dropdown should appear
- [ ] Change pg_size — URL updates, page resets to 1, gallery re-renders
- [ ] Browse small gallery (<500 items) at default — dropdown hidden
- [ ] Set `?pg_size=1000` manually on small gallery — dropdown appears
- [ ] Select 500 (default) from dropdown when at 1000 — correctly resets to 500
- [ ] Verify mobile layout — dropdown fits in flex-wrap controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)